### PR TITLE
Publish to pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,18 +1,53 @@
-name: Publish
+name: Publish to TestPyPI
 
-on:
-  release:
-    types: [published]
+on: push
+
+#on:
+#    release:
+#      types: [published]
 
 jobs:
-  test:
-    uses: ./github/workflows/test.yml
+    build:
+        name: Build distribution 📦
+        runs-on: ubuntu-latest
+    
+        steps:
+        - uses: actions/checkout@v4
+        - name: Set up Python
+          uses: actions/setup-python@v5
+          with:
+            python-version: "3.x"
+        - name: Install pypa/build
+          run: >-
+            python3 -m
+            pip install
+            build
+            --user
+        - name: Build a binary wheel and a source tarball
+          run: python3 -m build
+        - name: Store the distribution packages
+          uses: actions/upload-artifact@v3
+          with:
+            name: python-package-distributions
+            path: dist/
 
-  publish:
-    runs-on: ubuntu-latest
-    needs: test
-
-    steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
+    publish-to-pypi:
+        name: >-
+            Publish Python 🐍 distribution 📦 to PyPI
+        if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+        needs:
+        - build
+        runs-on: ubuntu-latest
+        environment:
+            name: pypi
+            url: https://test.pypi.org/p/labthings-fastapi
+        permissions:
+            id-token: write  # IMPORTANT: mandatory for trusted publishing
+        steps:
+            - name: Download all the dists
+              uses: actions/download-artifact@v3
+              with:
+                name: python-package-distributions
+                path: dist/
+            - name: Publish distribution 📦 to PyPI
+              uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,26 +26,50 @@ jobs:
         - name: Build a binary wheel and a source tarball
           run: python3 -m build
         - name: Store the distribution packages
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           with:
             name: python-package-distributions
             path: dist/
 
+    publish-to-testpypi:
+      name: Publish Python 🐍 distribution 📦 to TestPyPI
+      needs:
+      - build
+      runs-on: ubuntu-latest
+  
+      environment:
+        name: testpypi
+        url: https://test.pypi.org/p/labthings-fastapi
+  
+      permissions:
+        id-token: write  # IMPORTANT: mandatory for trusted publishing
+  
+      steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
     publish-to-pypi:
         name: >-
             Publish Python 🐍 distribution 📦 to PyPI
-        if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+        if: startsWith(github.ref, 'refs/tags/v')  # only publish to PyPI on tag pushes
         needs:
         - build
         runs-on: ubuntu-latest
         environment:
             name: pypi
-            url: https://test.pypi.org/p/labthings-fastapi
+            url: https://pypi.org/p/labthings-fastapi
         permissions:
             id-token: write  # IMPORTANT: mandatory for trusted publishing
         steps:
             - name: Download all the dists
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                 name: python-package-distributions
                 path: dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Install Dependencies
-        run: pip install -e .[dev]
+        run: pip install -e .[dev,server]
 
       - name: Lint with Ruff
         run: ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "labthings-fastapi"
-version = "0.0.0"
+version = "0.0.1"
 authors = [
   { name="Richard Bowman", email="richard.bowman@cantab.net" },
 ]
@@ -13,7 +13,6 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 dependencies = [
-  "fastapi[all]>=0.104.0",
   "pydantic>=2.0.0",
   "jsonschema",
   "typing_extensions",
@@ -28,6 +27,9 @@ dev = [
   "ruff>=0.1.3",
   "types-jsonschema",
   "numpy~=1.20",
+]
+server = [
+  "fastapi[all]>=0.104.0", # NB must match FastAPI above
 ]
 
 [project.urls]


### PR DESCRIPTION
`labthings-fastapi` can now be installed from PyPI. Each commit will be built and uploaded to test.pypi.org, and tagged versions will be uploaded to the real thing.

Due to an error during testing, `v0.0.1` has already been pushed to PyPI. I will tag the merge commit of this MR; it's not strictly the commit that resulted in the published package, but the code has not changed - this branch only touches CI, and the configuration in `pyproject.toml` is identical to what was published.

I've split the optional dependencies, so there's now a "server" option. This means that the package can be installed without `fastapi`. At present, nothing is guaranteed to work - though the `client` module ought to work OK.