### PR TITLE
Revert pydantic numpy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.base_ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/src/labthings_fastapi/types/numpy.py
+++ b/src/labthings_fastapi/types/numpy.py
@@ -22,19 +22,58 @@ from __future__ import annotations
 import numpy as np
 from pydantic import (
     ConfigDict,
+    PlainSerializer,
+    PlainValidator,
     RootModel,
     SerializerFunctionWrapHandler,
+    WithJsonSchema,
     WrapSerializer,
 )
-from typing import Annotated, Any, Union
-from typing_extensions import TypeAlias
+from typing import Annotated, Any, List, Union
 from collections.abc import Mapping, Sequence
 
-from pydantic_numpy.typing import NpNDArray  # type: ignore
 
-# This is here for backwards compatibility. Ideally, we should just
-# use types from `pydantic_numpy.typing` directly.
-NDArray: TypeAlias = Union[NpNDArray, int, float]
+# Define a nested list of floats with 0-6 dimensions
+# This would be most elegantly defined as a recursive type
+# but the below gets the job done for now.
+Number = Union[int, float]
+NestedListOfNumbers = Union[
+    Number,
+    List[Number],
+    List[List[Number]],
+    List[List[List[Number]]],
+    List[List[List[List[Number]]]],
+    List[List[List[List[List[Number]]]]],
+    List[List[List[List[List[List[Number]]]]]],
+    List[List[List[List[List[List[List]]]]]],
+]
+
+
+class NestedListOfNumbersModel(RootModel):
+    root: NestedListOfNumbers
+
+
+def np_to_listoflists(arr: np.ndarray) -> NestedListOfNumbers:
+    """Convert a numpy array to a list of lists
+
+    NB this will not be quick! Large arrays will be much better
+    serialised by dumping to base64 encoding or similar.
+    """
+    return arr.tolist()
+
+
+def listoflists_to_np(lol: Union[NestedListOfNumbers, np.ndarray]) -> np.ndarray:
+    """Convert a list of lists to a numpy array (or pass-through ndarrays)"""
+    return np.asarray(lol)
+
+
+# Define an annotated type so Pydantic can cope with numpy
+NDArray = Annotated[
+    np.ndarray,
+    PlainValidator(listoflists_to_np),
+    PlainSerializer(np_to_listoflists, when_used="json-unless-none"),
+    WithJsonSchema(NestedListOfNumbersModel.model_json_schema(), mode="validation"),
+]
 
 
 def denumpify(v: Any) -> Any:

--- a/tests/test_numpy_type.py
+++ b/tests/test_numpy_type.py
@@ -4,6 +4,8 @@ from pydantic import BaseModel
 import numpy as np
 
 from labthings_fastapi.types.numpy import NDArray
+from labthings_fastapi.thing import Thing
+from labthings_fastapi.decorators import thing_action
 
 
 def check_field_works_with_list(data):
@@ -55,3 +57,12 @@ def test_0d():
     assert d["a"] == 1
     m.model_json_schema()
     m.model_dump_json()
+
+class MyNumpyThing(Thing):
+    @thing_action
+    def action_with_arrays(self, a: NDArray) -> NDArray:
+        return a * 2
+
+def test_thing_description():
+    thing = MyNumpyThing()
+    assert thing.validate_thing_description() is None

--- a/tests/test_numpy_type.py
+++ b/tests/test_numpy_type.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pydantic import BaseModel
 import numpy as np
 
-from labthings_fastapi.types.numpy import NDArray
+from labthings_fastapi.types.numpy import NDArray, DenumpifyingDict
 from labthings_fastapi.thing import Thing
 from labthings_fastapi.decorators import thing_action
 
@@ -68,3 +68,14 @@ class MyNumpyThing(Thing):
 def test_thing_description():
     thing = MyNumpyThing()
     assert thing.validate_thing_description() is None
+
+def test_denumpifying_dict():
+    d = DenumpifyingDict(
+        root={
+            "a": np.array([1, 2, 3]),
+            "b": [np.arange(10), np.arange(10)],
+            "c": {"ca": np.array([1, 2, 3])},
+            "d": {"da": [np.arange(10), np.arange(10)]},
+        })
+    d.model_dump()
+    d.model_dump_json()

--- a/tests/test_numpy_type.py
+++ b/tests/test_numpy_type.py
@@ -69,6 +69,7 @@ def test_thing_description():
     thing = MyNumpyThing()
     assert thing.validate_thing_description() is None
 
+
 def test_denumpifying_dict():
     d = DenumpifyingDict(
         root={
@@ -76,6 +77,7 @@ def test_denumpifying_dict():
             "b": [np.arange(10), np.arange(10)],
             "c": {"ca": np.array([1, 2, 3])},
             "d": {"da": [np.arange(10), np.arange(10)]},
-        })
+        }
+    )
     d.model_dump()
     d.model_dump_json()

--- a/tests/test_numpy_type.py
+++ b/tests/test_numpy_type.py
@@ -77,7 +77,12 @@ def test_denumpifying_dict():
             "b": [np.arange(10), np.arange(10)],
             "c": {"ca": np.array([1, 2, 3])},
             "d": {"da": [np.arange(10), np.arange(10)]},
+            "e": None,
+            "f": 1,
         }
     )
-    d.model_dump()
+    dump = d.model_dump()
+    assert dump["a"] == [1, 2, 3]
+    assert dump["e"] is None
+    assert dump["f"] == 1
     d.model_dump_json()

--- a/tests/test_numpy_type.py
+++ b/tests/test_numpy_type.py
@@ -58,10 +58,12 @@ def test_0d():
     m.model_json_schema()
     m.model_dump_json()
 
+
 class MyNumpyThing(Thing):
     @thing_action
     def action_with_arrays(self, a: NDArray) -> NDArray:
         return a * 2
+
 
 def test_thing_description():
     thing = MyNumpyThing()


### PR DESCRIPTION
This swaps back to the built in `NDArray` Pydantic type hint, fixing #79 

Fixes #79 