### PR TITLE
Relax numpy constraint for compatibility with older libraries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "labthings-fastapi"
-version = "0.0.4"
+version = "0.0.5"
 authors = [
   { name="Richard Bowman", email="richard.bowman@cantab.net" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
   "pydantic>=2.0.0",
-  "numpy~=2.0",
+  "numpy>=1.20",
   "pydantic_numpy>=6.0",
   "jsonschema",
   "typing_extensions",


### PR DESCRIPTION
I upgraded numpy and required 2.0 to get `pydantic-numpy` working. However, I've since reverted that as it didn't work with the thing descriptions as I hoped. I am now relaxing the numpy specification, as it enable compatibility with some older libraries.