### PR TITLE
Remove no-longer-needed dependency on pydantic-numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "labthings-fastapi"
-version = "0.0.5"
+version = "0.0.6"
 authors = [
   { name="Richard Bowman", email="richard.bowman@cantab.net" },
 ]
@@ -15,7 +15,6 @@ classifiers = [
 dependencies = [
   "pydantic>=2.0.0",
   "numpy>=1.20",
-  "pydantic_numpy>=6.0",
   "jsonschema",
   "typing_extensions",
   "anyio ~=4.0",


### PR DESCRIPTION
I reverted the move to `pydantic-numpy` but failed to remove the dependency from metadata. This causes problematic interactions with packages that can't use numpy v2 (including the most recent version of OpenCV to work on the Pi).

This removes the dependency on pydantic-numpy to re-enable compatibility with those packages.