### PR TITLE
Blob input

### DIFF
--- a/src/labthings_fastapi/actions/__init__.py
+++ b/src/labthings_fastapi/actions/__init__.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 import weakref
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import FileResponse
-from pydantic import BaseModel, RootModel
+from pydantic import BaseModel
 
 from labthings_fastapi.utilities import model_to_dict
 from labthings_fastapi.utilities.introspection import EmptyInput
@@ -176,16 +176,6 @@ class Invocation(Thread):
 
             action = self.action
             thing = self.thing
-            #kwargs = self.input.model_dump() or {}
-            # if isinstance(self.input, RootModel):
-            #     if self.input.root is not None:
-            #         print(f"confused by {self.input}")
-            #         raise ValueError("RootModel inputs are only used for None")
-            #     kwargs = {}
-            # elif isinstance(self.input, BaseModel):
-            #     kwargs = dict(self.input)
-            # else:
-            #     kwargs = {}
             kwargs = model_to_dict(self.input)
             assert action is not None
             assert thing is not None
@@ -338,7 +328,9 @@ class ActionManager:
             response_model=InvocationModel,
             responses={404: {"description": "Invocation ID not found"}},
         )
-        def action_invocation(id: uuid.UUID, request: Request, _blob_manager: BlobIOContextDep):
+        def action_invocation(
+            id: uuid.UUID, request: Request, _blob_manager: BlobIOContextDep
+        ):
             try:
                 with self._invocations_lock:
                     return self._invocations[id].response(request=request)

--- a/src/labthings_fastapi/actions/__init__.py
+++ b/src/labthings_fastapi/actions/__init__.py
@@ -282,7 +282,7 @@ class ActionManager:
         self.append_invocation(thread)
         thread.start()
         return thread
-    
+
     def get_invocation(self, id: uuid.UUID) -> Invocation:
         """Retrieve an invocation by ID"""
         with self._invocations_lock:

--- a/src/labthings_fastapi/actions/__init__.py
+++ b/src/labthings_fastapi/actions/__init__.py
@@ -282,6 +282,11 @@ class ActionManager:
         self.append_invocation(thread)
         thread.start()
         return thread
+    
+    def get_invocation(self, id: uuid.UUID) -> Invocation:
+        """Retrieve an invocation by ID"""
+        with self._invocations_lock:
+            return self._invocations[id]
 
     def list_invocations(
         self,

--- a/src/labthings_fastapi/client/__init__.py
+++ b/src/labthings_fastapi/client/__init__.py
@@ -72,6 +72,10 @@ class ThingClient:
         r.raise_for_status()
 
     def invoke_action(self, path: str, **kwargs):
+        "Invoke an action on the Thing"
+        for k in kwargs.keys():
+            if isinstance(kwargs[k], ClientBlobOutput):
+                kwargs[k] = {"href": kwargs[k].href, "media_type": kwargs[k].media_type}
         r = self.client.post(urljoin(self.path, path), json=kwargs)
         r.raise_for_status()
         task = poll_task(self.client, r.json())
@@ -118,6 +122,7 @@ class ThingClient:
     @classmethod
     def subclass_from_td(cls, thing_description: dict) -> type[Self]:
         """Create a ThingClient subclass from a Thing Description"""
+        my_thing_description = thing_description
 
         class Client(cls):  # type: ignore[valid-type, misc]
             # mypy wants the superclass to be statically type-able, but
@@ -125,7 +130,7 @@ class ThingClient:
             # use this class method on `ThingClient` subclasses, i.e.
             # to provide customisation but also add methods from a
             # Thing Description.
-            pass
+            thing_description = my_thing_description
 
         for name, p in thing_description["properties"].items():
             add_property(Client, name, p)

--- a/src/labthings_fastapi/client/in_server.py
+++ b/src/labthings_fastapi/client/in_server.py
@@ -20,7 +20,7 @@ from labthings_fastapi.descriptors.property import PropertyDescriptor
 from labthings_fastapi.utilities import attributes
 from . import PropertyClientDescriptor
 from ..thing import Thing
-from ..server import find_thing_server
+from ..dependencies.thing_server import find_thing_server
 from fastapi import Request
 
 

--- a/src/labthings_fastapi/dependencies/action_manager.py
+++ b/src/labthings_fastapi/dependencies/action_manager.py
@@ -15,7 +15,8 @@ from __future__ import annotations
 
 from contextvars import ContextVar
 
-from typing import Annotated, TypeAlias
+from typing import Annotated
+from typing_extensions import TypeAlias
 from fastapi import Depends, Request
 from ..dependencies.thing_server import find_thing_server
 from ..actions import ActionManager

--- a/src/labthings_fastapi/dependencies/action_manager.py
+++ b/src/labthings_fastapi/dependencies/action_manager.py
@@ -33,9 +33,7 @@ def action_manager_from_thing_server(request: Request) -> ActionManager:
     return action_manager
 
 
-ActionManagerDep = Annotated[
-    ActionManager, Depends(action_manager_from_thing_server)
-]
+ActionManagerDep = Annotated[ActionManager, Depends(action_manager_from_thing_server)]
 """
 A ready-made dependency type for the `ActionManager` object.
 """
@@ -46,11 +44,13 @@ ActionManagerContext = ContextVar[ActionManager]("ActionManagerContext")
 
 async def make_action_manager_context_available(action_manager: ActionManagerDep):
     """Make the Action Manager available in the context
-    
+
     The action manager may be accessed using `ActionManagerContext.get()`.
     """
     ActionManagerContext.set(action_manager)
     yield action_manager
 
 
-ActionManagerContextDep: TypeAlias = Annotated[ActionManager, Depends(make_action_manager_context_available)]
+ActionManagerContextDep: TypeAlias = Annotated[
+    ActionManager, Depends(make_action_manager_context_available)
+]

--- a/src/labthings_fastapi/dependencies/action_manager.py
+++ b/src/labthings_fastapi/dependencies/action_manager.py
@@ -1,0 +1,56 @@
+"""
+Context Var access to the Action Manager
+
+This module provides a context var to access the Action Manager instance.
+While LabThings tries pretty hard to conform to FastAPI's excellent convention
+that everything should be passed as a parameter, there are some cases where
+that's hard. In particular, generating URLs when responses are serialised is
+difficult, because `pydantic` doesn't have a way to pass in extra context.
+
+If an endpoint uses the `ActionManagerDep` dependency, then the Action Manager
+is available using `ActionManagerContext.get()`.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+
+from typing import Annotated, TypeAlias
+from fastapi import Depends, Request
+from ..dependencies.thing_server import find_thing_server
+from ..actions import ActionManager
+
+
+def action_manager_from_thing_server(request: Request) -> ActionManager:
+    """Retrieve the Action Manager from the Thing Server
+
+    This is for use as a FastAPI dependency, so the thing server is
+    retrieved from the request object.
+    """
+    action_manager = find_thing_server(request.app).action_manager
+    if action_manager is None:
+        raise RuntimeError("Could not get the blocking portal from the server.")
+    return action_manager
+
+
+ActionManagerDep = Annotated[
+    ActionManager, Depends(action_manager_from_thing_server)
+]
+"""
+A ready-made dependency type for the `ActionManager` object.
+"""
+
+
+ActionManagerContext = ContextVar[ActionManager]("ActionManagerContext")
+
+
+async def make_action_manager_context_available(action_manager: ActionManagerDep):
+    """Make the Action Manager available in the context
+    
+    The action manager may be accessed using `ActionManagerContext.get()`.
+    """
+    ActionManagerContext.set(action_manager)
+    yield action_manager
+
+
+ActionManagerContextDep: TypeAlias = Annotated[ActionManager, Depends(make_action_manager_context_available)]

--- a/src/labthings_fastapi/dependencies/blocking_portal.py
+++ b/src/labthings_fastapi/dependencies/blocking_portal.py
@@ -12,10 +12,10 @@ from ..server import find_thing_server
 
 
 def blocking_portal_from_thing_server(request: Request) -> RealBlockingPortal:
-    """Return a UUID for an action invocation
+    """Return the blocking portal from our ThingServer
 
-    This is for use as a FastAPI dependency, to allow other dependencies to
-    access the invocation ID. Useful for e.g. file management.
+    This is for use as a FastAPI dependency, to allow threaded code to call
+    async code.
     """
     portal = find_thing_server(request.app).blocking_portal
     if portal is None:

--- a/src/labthings_fastapi/dependencies/blocking_portal.py
+++ b/src/labthings_fastapi/dependencies/blocking_portal.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import Annotated
 from fastapi import Depends, Request
 from anyio.from_thread import BlockingPortal as RealBlockingPortal
-from ..server import find_thing_server
+from .thing_server import find_thing_server
 
 
 def blocking_portal_from_thing_server(request: Request) -> RealBlockingPortal:

--- a/src/labthings_fastapi/dependencies/metadata.py
+++ b/src/labthings_fastapi/dependencies/metadata.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 
 from fastapi import Depends, Request
 
-from ..server import find_thing_server
+from .thing_server import find_thing_server
 
 
 def thing_states_getter(request: Request) -> Callable[[], Mapping[str, Any]]:

--- a/src/labthings_fastapi/dependencies/raw_thing.py
+++ b/src/labthings_fastapi/dependencies/raw_thing.py
@@ -4,7 +4,7 @@ from typing import Annotated, Callable, TypeVar
 from fastapi import Depends, Request
 
 from ..thing import Thing
-from ..server import find_thing_server
+from .thing_server import find_thing_server
 
 
 ThingInstance = TypeVar("ThingInstance", bound=Thing)

--- a/src/labthings_fastapi/dependencies/thing_server.py
+++ b/src/labthings_fastapi/dependencies/thing_server.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 from weakref import WeakSet
-from typing import TYPE_CHECKING, Annotated
-from fastapi import FastAPI, Depends, Request
+from typing import TYPE_CHECKING
+from fastapi import FastAPI, Request
 
 if TYPE_CHECKING:
-    from .thing_server import ThingServer
+    from labthings_fastapi.server import ThingServer
 
 _thing_servers: WeakSet[ThingServer] = WeakSet()
 
@@ -15,6 +15,7 @@ def find_thing_server(app: FastAPI) -> ThingServer:
         if server.app == app:
             return server
     raise RuntimeError("No ThingServer found for this app")
+
 
 def thing_server_from_request(request: Request) -> ThingServer:
     """Retrieve the Action Manager from the Thing Server

--- a/src/labthings_fastapi/dependencies/thing_server.py
+++ b/src/labthings_fastapi/dependencies/thing_server.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+from weakref import WeakSet
+from typing import TYPE_CHECKING, Annotated
+from fastapi import FastAPI, Depends, Request
+
+if TYPE_CHECKING:
+    from .thing_server import ThingServer
+
+_thing_servers: WeakSet[ThingServer] = WeakSet()
+
+
+def find_thing_server(app: FastAPI) -> ThingServer:
+    """Find the ThingServer associated with an app"""
+    for server in _thing_servers:
+        if server.app == app:
+            return server
+    raise RuntimeError("No ThingServer found for this app")
+
+def thing_server_from_request(request: Request) -> ThingServer:
+    """Retrieve the Action Manager from the Thing Server
+
+    This is for use as a FastAPI dependency, so the thing server is
+    retrieved from the request object.
+    """
+    return find_thing_server(request.app)

--- a/src/labthings_fastapi/dependencies/thing_server.py
+++ b/src/labthings_fastapi/dependencies/thing_server.py
@@ -1,3 +1,11 @@
+"""
+Retrieve the ThingServer object
+
+This module provides a function that will retrieve the ThingServer
+based on the `Request` object. It may be used as a dependency with:
+`Annotated[ThingServer, Depends(thing_server_from_request)]`.
+"""
+
 from __future__ import annotations
 from weakref import WeakSet
 from typing import TYPE_CHECKING

--- a/src/labthings_fastapi/descriptors/action.py
+++ b/src/labthings_fastapi/descriptors/action.py
@@ -20,7 +20,7 @@ from ..utilities.introspection import (
     input_model_from_signature,
     return_type,
 )
-from ..outputs.blob import blob_to_model, get_model_media_type
+from ..outputs.blob import BlobIOContextDep
 from ..thing_description import type_to_dataschema
 from ..thing_description.model import ActionAffordance, ActionOp, Form, Union
 
@@ -70,7 +70,7 @@ class ActionDescriptor:
             remove_first_positional_arg=True,
             ignore=[p.name for p in self.dependency_params],
         )
-        self.output_model = blob_to_model(return_type(func))
+        self.output_model = return_type(func)
         self.invocation_model = create_model(
             f"{self.name}_invocation",
             __base__=InvocationModel,
@@ -165,6 +165,7 @@ class ActionDescriptor:
         # the function to the decorator.
         def start_action(
             action_manager: ActionManagerContextDep,
+            _blob_manager: BlobIOContextDep,
             request: Request,
             body,
             id: InvocationID,
@@ -221,8 +222,8 @@ class ActionDescriptor:
         except AttributeError:
             print(f"Failed to generate response model for action {self.name}")
         # Add an additional media type if we may return a file
-        if get_model_media_type(self.output_model):
-            responses[200]["content"][get_model_media_type(self.output_model)] = {}
+        if hasattr(self.output_model, "media_type"):
+            responses[200]["content"][self.output_model.media_type] = {}
         # Now we can add the endpoint to the app.
         app.post(
             thing.path + self.name,

--- a/src/labthings_fastapi/file_manager.py
+++ b/src/labthings_fastapi/file_manager.py
@@ -1,5 +1,7 @@
 """Manage files created by Actions
 
+**This module is deprecated in favour of `labthings_fastapi.outputs.blob`**
+
 Simple actions return everything you need to know about them in their return value,
 which can be serialised to JSON. More complicated actions might need to return
 more complicated responses, for example files.
@@ -12,6 +14,7 @@ files via the Invocation object.
 from __future__ import annotations
 from tempfile import TemporaryDirectory
 from typing import Annotated, Sequence, Optional
+from warnings import warn
 
 from fastapi import Depends, Request
 
@@ -27,6 +30,10 @@ class FileManager:
     __globals__ = globals()  # "bake in" globals so dependency injection works
 
     def __init__(self, invocation_id: InvocationID, request: Request):
+        warn(
+            "FileManager is deprecated in favour of labthings_fastapi.outputs.blob",
+            DeprecationWarning,
+        )
         self.invocation_id = invocation_id
         self._links: set[tuple[str, str]] = set()
         self._dir = TemporaryDirectory(prefix=f"labthings-{self.invocation_id}-")

--- a/src/labthings_fastapi/outputs/blob.py
+++ b/src/labthings_fastapi/outputs/blob.py
@@ -30,10 +30,10 @@ from typing import (
     Literal,
     Mapping,
     Optional,
-    TypeAlias,
     Union,
     TYPE_CHECKING,
 )
+from typing_extensions import TypeAlias
 from tempfile import TemporaryDirectory
 import uuid
 

--- a/src/labthings_fastapi/server/__init__.py
+++ b/src/labthings_fastapi/server/__init__.py
@@ -17,6 +17,7 @@ from ..thing_settings import ThingSettings
 from ..thing import Thing
 from ..thing_description.model import ThingDescription
 from ..dependencies.thing_server import _thing_servers
+from ..outputs.blob import BlobDataManager
 
 
 class ThingServer:
@@ -26,6 +27,8 @@ class ThingServer:
         self.settings_folder = settings_folder or "./settings"
         self.action_manager = ActionManager()
         self.action_manager.attach_to_app(self.app)
+        self.blob_data_manager = BlobDataManager()
+        self.blob_data_manager.attach_to_app(self.app)
         self.add_things_view_to_app()
         self._things: dict[str, Thing] = {}
         self.blocking_portal: Optional[BlockingPortal] = None

--- a/src/labthings_fastapi/server/__init__.py
+++ b/src/labthings_fastapi/server/__init__.py
@@ -38,6 +38,7 @@ class ThingServer:
 
     app: FastAPI
     action_manager: ActionManager
+    blob_data_manager: BlobDataManager
 
     def set_cors_middleware(self) -> None:
         self.app.add_middleware(

--- a/src/labthings_fastapi/server/__init__.py
+++ b/src/labthings_fastapi/server/__init__.py
@@ -6,7 +6,6 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from anyio.from_thread import BlockingPortal
 from contextlib import asynccontextmanager, AsyncExitStack
-from weakref import WeakSet
 from collections.abc import Mapping
 from types import MappingProxyType
 
@@ -17,17 +16,7 @@ from ..actions import ActionManager
 from ..thing_settings import ThingSettings
 from ..thing import Thing
 from ..thing_description.model import ThingDescription
-
-
-_thing_servers: WeakSet[ThingServer] = WeakSet()
-
-
-def find_thing_server(app: FastAPI) -> ThingServer:
-    """Find the ThingServer associated with an app"""
-    for server in _thing_servers:
-        if server.app == app:
-            return server
-    raise RuntimeError("No ThingServer found for this app")
+from ..dependencies.thing_server import _thing_servers
 
 
 class ThingServer:

--- a/src/labthings_fastapi/utilities/__init__.py
+++ b/src/labthings_fastapi/utilities/__init__.py
@@ -60,3 +60,12 @@ def wrap_plain_types_in_rootmodel(model: type) -> type[BaseModel]:
         return model
     except (TypeError, AssertionError):
         return create_model(f"{model!r}", root=(model, ...), __base__=RootModel)
+
+
+def model_to_dict(model: Optional[BaseModel]) -> Dict[str, Any]:
+    """Convert a pydantic model to a dictionary"""
+    if model is None:
+        return {}
+    if isinstance(model, RootModel):
+        return model_to_dict(model.root)
+    return dict(model)

--- a/src/labthings_fastapi/utilities/__init__.py
+++ b/src/labthings_fastapi/utilities/__init__.py
@@ -4,6 +4,7 @@ from weakref import WeakSet
 from pydantic import BaseModel, ConfigDict, Field, RootModel, create_model
 from pydantic.dataclasses import dataclass
 from anyio.from_thread import BlockingPortal
+from labthings_fastapi.utilities.introspection import EmptyObject
 
 if TYPE_CHECKING:
     from ..thing import Thing
@@ -63,9 +64,23 @@ def wrap_plain_types_in_rootmodel(model: type) -> type[BaseModel]:
 
 
 def model_to_dict(model: Optional[BaseModel]) -> Dict[str, Any]:
-    """Convert a pydantic model to a dictionary"""
+    """Convert a pydantic model to a dictionary
+
+    We convert only the top level model, i.e. we do not recurse into submodels.
+    This is important to avoid serialising Blob objects in action inputs.
+    This function returns `dict(model)`, with exceptions for the case of `None`
+    (converted to an empty dictionary) and `RootModel`s (checked to see if they
+    correspond to empty input).
+
+    If RootModels with non-empty input are allowed, this function will need to
+    be updated to handle them.
+    """
     if model is None:
         return {}
     if isinstance(model, RootModel):
-        return model_to_dict(model.root)
+        if model.root is None:
+            return {}
+        if isinstance(model.root, EmptyObject):
+            return {}
+        raise ValueError("RootModels with non-empty input are not supported")
     return dict(model)

--- a/src/labthings_fastapi/utilities/introspection.py
+++ b/src/labthings_fastapi/utilities/introspection.py
@@ -17,7 +17,6 @@ from inspect import Parameter, signature
 from pydantic import BaseModel, ConfigDict, Field, RootModel
 from pydantic.main import create_model
 from fastapi.dependencies.utils import analyze_param, get_typed_signature
-from labthings_fastapi.outputs.blob import BlobOutput, blob_output_model
 
 
 class EmptyObject(BaseModel):
@@ -94,12 +93,6 @@ def input_model_from_signature(
         # `type_hints` does more processing than p.annotation - but will
         # not have entries for missing annotations.
         p_type = Any if p.annotation is Parameter.empty else type_hints[name]
-        # Here, we add an exception for BlobOutput subclasses
-        try:
-            if issubclass(p_type, BlobOutput):
-                p_type = blob_output_model(p_type.media_type)
-        except TypeError:
-            print(f"{p_type} was not a class")
         # pydantic uses `...` to represent missing defaults (i.e. required params)
         default = Field(...) if p.default is Parameter.empty else p.default
         fields[name] = (p_type, default)

--- a/src/labthings_fastapi/utilities/introspection.py
+++ b/src/labthings_fastapi/utilities/introspection.py
@@ -95,7 +95,9 @@ def input_model_from_signature(
         p_type = Any if p.annotation is Parameter.empty else type_hints[name]
         # pydantic uses `...` to represent missing defaults (i.e. required params)
         default = Field(...) if p.default is Parameter.empty else p.default
-        fields[name] = (p_type, default)
+        # p_type below has a complicated type, but it is reasonable to
+        # call p_type a `type` and ignore the mypy error.
+        fields[name] = (p_type, default)  # type: ignore[assignment]
     model = create_model(  # type: ignore[call-overload]
         f"{func.__name__}_input",
         model_config=ConfigDict(extra="allow" if takes_v_kwargs else "forbid"),

--- a/src/labthings_fastapi/utilities/introspection.py
+++ b/src/labthings_fastapi/utilities/introspection.py
@@ -17,6 +17,7 @@ from inspect import Parameter, signature
 from pydantic import BaseModel, ConfigDict, Field, RootModel
 from pydantic.main import create_model
 from fastapi.dependencies.utils import analyze_param, get_typed_signature
+from labthings_fastapi.outputs.blob import BlobOutput, blob_output_model
 
 
 class EmptyObject(BaseModel):
@@ -93,6 +94,12 @@ def input_model_from_signature(
         # `type_hints` does more processing than p.annotation - but will
         # not have entries for missing annotations.
         p_type = Any if p.annotation is Parameter.empty else type_hints[name]
+        # Here, we add an exception for BlobOutput subclasses
+        try:
+            if issubclass(p_type, BlobOutput):
+                p_type = blob_output_model(p_type.media_type)
+        except TypeError:
+            print(f"{p_type} was not a class")
         # pydantic uses `...` to represent missing defaults (i.e. required params)
         default = Field(...) if p.default is Parameter.empty else p.default
         fields[name] = (p_type, default)


### PR DESCRIPTION
This PR allows blobs to be passed as input to actions. It's not yet fully general, but two important cases are supported:

1. *client* code can pass a `ClientBlobOutput` object as input to an action, for example `blob = thing.acquire_image()` then `thing.process_image(blob)`. This re-uses the blob on the server, so no large data transfer is needed. This does mean it will fail if the second call comes after the first invocation has been deleted.
2. *server* code can pass Blob objects as input to actions, with everything properly type-hinted. As we're using the objects directly, there's no reliance on the action manager and no data transfer overhead.

This should be particularly useful for camera code, for example allowing us to add processing steps that accept an image as input.

I'd like to extend it to include uploading BLOBs and downloading BLOBs from other servers - but that's a future feature.

## Implementation

I've consolidated BlobOutput and BlobModel into a single class, Blob, which is a subclass of BaseModel. This is a breaking change, but only because the name has changed from BlobOutput

In the serialisation and validation methods of Blob, I use context variables to generate URLs and retrieve Blob data. This means they can only be created from JSON or dumped if said context vars are set. This is done by a new FastAPI dependency.