### PR TITLE
Work with pydantic 2.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "labthings-fastapi"
-version = "0.0.6"
+version = "0.0.7"
 authors = [
   { name="Richard Bowman", email="richard.bowman@cantab.net" },
 ]


### PR DESCRIPTION
Pydantic 2.10 is stricter about forward references for types. This caused my `NDArray` annotated type to fail, because the return type of the serialiser function was not in scope when function input/output models were built.

This PR fixes the problem by explicitly specifying a `return_type` for the serialiser, and tidies up a few loose ends that appeared while debugging. A test is added to ensure this issue will trigger a failure if it recurs.