### PR TITLE
Draft: Code generation for ThingClient subclasses

### DIFF
--- a/src/labthings_fastapi/code_generation/__init__.py
+++ b/src/labthings_fastapi/code_generation/__init__.py
@@ -1,0 +1,168 @@
+from inspect import cleandoc
+import re
+from typing import Sequence
+
+from labthings_fastapi.thing_description.model import (
+    DataSchema,
+    ThingDescription,
+    Type,
+)
+
+
+def title_to_snake_case(title: str) -> str:
+    """Convert text to snake_case"""
+    words = re.findall(r"[a-z0-9]+", title.lower())
+    return "_".join(words)
+
+
+def snake_to_camel_case(snake: str) -> str:
+    """Convert snake_case to CamelCase"""
+    words = snake.split("_")
+    return "".join(word.capitalize() for word in words)
+
+
+def title_to_camel_case(title: str) -> str:
+    """Convert text to CamelCase"""
+    return snake_to_camel_case(title_to_snake_case(title))
+
+
+def clean_code(code: str, prefix: str = "") -> str:
+    """Clean up code by removing leading/trailing whitespace and empty lines"""
+    lines = cleandoc(code).split("\n")
+    return "\n".join([prefix + l for l in lines])
+
+
+def quoted_docstring(docstring: str, indent: int = 4) -> str:
+    """Wrap a docstring in triple quotes"""
+    prefix = " " * indent
+    lines = docstring.split("\n")
+    lines[0] = f'"""{lines[0]}'
+    lines.append('"""')
+    return "".join([f"{prefix}{line}\n" for line in lines])
+
+
+def dataschema_to_type(schema: DataSchema) -> str:
+    """Convert a DataSchema to a Python type"""
+    if isinstance(schema.oneOf, Sequence) and len(schema.oneOf) > 0:
+        types = [dataschema_to_type(s) for s in schema.oneOf]
+        return f"Union[{", ".join(types)}]"
+    if schema.type == Type.string:
+        return "str"
+    elif schema.type == Type.integer:
+        return "int"
+    elif schema.type == Type.number:
+        return "float"
+    elif schema.type == Type.boolean:
+        return "bool"
+    elif schema.type == Type.array:
+        if schema.items is None:
+            return "list"
+        return f"list[{dataschema_to_type(schema.items)}]"
+    elif schema.type == Type.object:
+        return "dict[str, Any]"
+    else:
+        return "Any"
+
+def property_to_argument(
+        name: str,
+        property: DataSchema,
+    ) -> str:
+    """Convert a property to a function argument"""
+    dtype = dataschema_to_type(property)
+    arg = f"{name}: {dtype}"
+    if "default" in property.model_fields_set:
+        if property.default is None:
+            arg += " = None"
+        elif isinstance(property.default, str):
+            arg += f' = "{property.default}"'
+        elif (
+            isinstance(property.default, bool)
+            or isinstance(property.default, int)
+            or isinstance(property.default, float)
+        ):
+            arg += f" = {property.default}"
+        else:
+            raise NotImplementedError(f"Unsupported default value: {property.default}")
+    return arg
+
+
+def input_model_to_arguments(model: DataSchema) -> list[str]:
+    """Convert an input model to a list of arguments"""
+    if model.type is None:
+        return []
+    if model.type != Type.object:
+        print(f"model.type: {model.type}")
+        raise NotImplementedError("Only object models are supported")
+    if not model.properties:
+        return []
+    args = []
+    if model.required:
+        for name in model.required:
+            property = model.properties[name]
+            args.append(
+                property_to_argument(name, property)
+            )
+    for name, property in model.properties.items():
+        if model.required and name in model.required:
+            continue
+        args.append(property_to_argument(name, property))
+        if "=" not in args[-1]:
+            args[-1] += " = ..."
+    return args
+
+
+def generate_client(thing_description: ThingDescription) -> str:
+    """Generate a client from a Thing Description"""
+    code = (
+        "from labthings_fastapi.client import ThingClient\n"
+        "from typing import Any, Union\n"
+        "\n"
+    )
+    class_name = title_to_camel_case(thing_description.title)
+    code += f"class {class_name}Client(ThingClient):\n"
+    code += f'    """A client for the {thing_description.title} Thing"""\n\n'
+    for name, property in thing_description.properties.items():
+        pname = title_to_snake_case(name)
+        dtype = dataschema_to_type(property)
+        code += "    @property\n"
+        code += f"    def {pname}(self) -> {dtype}:\n"
+        code += quoted_docstring(property.description, indent=8)
+        code += f'        return self.get_property("{name}")\n\n'
+
+        if not property.readOnly:
+            code += clean_code(
+                f'''
+                @{pname}.setter
+                def {pname}(self, value: {dtype}):
+                    self.set_property("{name}", value)
+                ''',
+                prefix = "    ",
+            ) + "\n\n"
+    
+    for name, action in thing_description.actions.items():
+        aname = title_to_snake_case(name)
+        args = input_model_to_arguments(action.input)
+        output_type = dataschema_to_type(action.output)
+        code += f"    def {aname}(\n"
+        code += "        self,\n"
+        for arg in args:
+            code += f"        {arg},\n"
+        code += "        **kwargs\n"
+        code += f"    ) -> {output_type}:\n"
+        code += quoted_docstring(action.description, indent=8)
+        for arg in args:
+            k = arg.split(":")[0].strip()
+            if arg.endswith("..."):
+                code += clean_code(
+                    f"""
+                    if {k} is not ...:
+                        kwargs[{k}] = {k}
+                    """,
+                    prefix = "        ",
+                ) + "\n"
+            else:
+                code += f"        kwargs[{k}] = {k}\n"
+        code += f'        return self.invoke_action("{name}", **kwargs)\n\n'
+
+    return code
+

--- a/tests/test_client_generation.py
+++ b/tests/test_client_generation.py
@@ -1,0 +1,26 @@
+import os
+import tempfile
+import importlib.util
+
+from labthings_fastapi.code_generation import generate_client
+from labthings_fastapi.example_things import MyThing
+
+
+def test_client_generation():
+    td = MyThing().thing_description()
+    code = generate_client(td)
+    with tempfile.TemporaryDirectory() as d:
+        fname = os.path.join(d,"client.py")
+        with open(fname, "w") as f:
+            f.write(code)
+        spec = importlib.util.spec_from_file_location("client", f.name)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    assert "MyThingClient" in dir(module)
+    
+if __name__ == "__main__":
+    td = MyThing().thing_description()
+    print("Thing Description:")
+    print(td.model_dump_json(indent=2, exclude_unset=True))
+    print("\nGenerated Client:")
+    print(generate_client(td))


### PR DESCRIPTION
Currently, `ThingClient` subclasses are generated on-the-fly from a Thing Description. This "gets the job done" and means it's always possible to have a client that's up to date with the server. However, it would be nice to support static analysis, e.g. type checking, autocompletion, etc. with importable client classes for specific instruments.

## Functionality
This PR implements client code generation, specifically:

* A client class is created, subclassing `ThingClient` and named as per the `title` of the Thing Description.
* Properties are added using their names from the TD
    - Property types are converted to Python type hints (with very basic conversion)
    - Read-only properties are made read-only. Write-only properties still have a read method.
    - Implementations use  `get_property`, `set_property` as provided by `ThingClient`
* Actions are added using names from the TD
    - The input schema is broken down into its properties (i.e. arguments), and each property's schema is converted to an argument with a type hint and default.
    - Required properties of the input schema become required arguments
    - Additional keyword arguments are always accepted and passed to the endpoint - TD `DataSchema` objects don't distinguish whether extra properties are allowed or not.
    - The output schema is converted to a return type hint
    - The function body calls `invoke_action`. 
    - `...` is used to distinguish between explicitly set `None` values, and unspecified values (i.e. not included in the JSON). This allows for values or defaults that are `None` to be handled differently from properties that are optional but don't have a default.
 
## Schema conversion
Conversion from `DataSchema` to Python types is implemented partially. Types are converted recursively, with support for:
* `integer` -> `int`
* `number` -> `float`
* `boolean` -> `bool`
* `string` -> `str`
* `anyOf` -> `Union`
* `array` -> `List` (if an item type is specified, it's converted recursively)
* `object` -> `dict[str, Any`
* Anything else -> `Any`

The major limitation here is that `object` gets converted to a `dict` so we don't get hints for each property. We'd need to use a `typeddict` or `dataclass` or similar to get that functionality, and for now I'm going to consider it out of scope. However, there's one exception, which is the input schema of an Action. That is currently required to be an `object`, and we map each of its properties

## Still to do
Before this is useful, we need to add a few things:

- [ ] * More testing, including all the data types and actual use of the created class.
- [ ] * Instantiation: currently, I believe calling `from_url` will overwrite the methods with generic ones.
- [ ] * Implementation using HTTP or Direct clients - i.e. so one client class works on the server or a network client. This could be done by defining a protocol that provides `get_property` and friends and implementations of that roughly equivalent to `DirectThingClient` and `ThingCilent`, and then providing a base client class with class methods `from_url` and `from_thing` that create a subclass that mixes in either `DirectThingClient` or `HTTPThingClient` as appropriate.
- [ ] * In both of the above cases, it would be nice to check that the methods/properties of the generated client class match the Thing Description of the thing we're connecting to. Extra affordances on the thing could be added dynamically, but it would be good to check the methods/properties of the client are all implemented on the server.