### PR TITLE
Add more information to the fallback server

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+concurrency = multiprocessing
+parallel = true
+sigterm = true

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,4 @@
 concurrency = multiprocessing, thread
 parallel = true
 sigterm = true
+omit = tests/**/*.py, docs/**/*.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 [run]
-concurrency = multiprocessing
+concurrency = multiprocessing, thread
 parallel = true
 sigterm = true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: 3.12
 
       - name: Install Dependencies
-        run: pip install -e .[dev,server]
+        run: pip install -e . -r dev-requirements.txt
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   base_coverage:
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -111,17 +112,33 @@ jobs:
           name: coverage-3.12
 
       - name: Download code coverage report for base branch
+        id: download-base-coverage
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: base-coverage.lcov
         
       - name: Generate Code Coverage report
+        # Note, due to continue on error (to make job pass) we need to check the
+        # Status of the step directly not just use success() or failure()
+        if: steps.download-base-coverage.outcome == 'success'
         id: code-coverage
         uses: barecheck/code-coverage-action@v1
         with:
           barecheck-github-app-token: ${{ secrets.BARECHECK_GITHUB_APP_TOKEN }}
           lcov-file: "./coverage.lcov"
           base-lcov-file: "./base-coverage.lcov"
+          minimum-ratio: 0
+          send-summary-comment: true
+          show-annotations: "warning"
+        
+      - name: Generate Code Coverage report if base job fails
+        if: steps.download-base-coverage.outcome == 'failure'
+        id: code-coverage-without-base
+        uses: barecheck/code-coverage-action@v1
+        with:
+          barecheck-github-app-token: ${{ secrets.BARECHECK_GITHUB_APP_TOKEN }}
+          lcov-file: "./coverage.lcov"
           minimum-ratio: 0
           send-summary-comment: true
           show-annotations: "warning"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "labthings-fastapi"
-version = "0.0.7"
+version = "0.0.8"
 authors = [
   { name="Richard Bowman", email="richard.bowman@cantab.net" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 dependencies = [
-  "pydantic>=2.0.0",
+  "pydantic ~= 2.10.6",
   "numpy>=1.20",
   "jsonschema",
   "typing_extensions",

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -1,0 +1,64 @@
+from fastapi.testclient import TestClient
+from labthings_fastapi.server import server_from_config
+from labthings_fastapi.server.fallback import app
+
+
+def test_fallback_empty():
+    with TestClient(app) as client:
+        response = client.get("/")
+        html = response.text
+        # test that something when wrong is shown
+        assert "Something went wrong" in html
+        assert "No logging info available" in html
+
+
+def test_fallback_with_config():
+    app.labthings_config = {"hello": "goodbye"}
+    with TestClient(app) as client:
+        response = client.get("/")
+        html = response.text
+        assert "Something went wrong" in html
+        assert "No logging info available" in html
+        assert '"hello": "goodbye"' in html
+
+
+def test_fallback_with_error():
+    app.labthings_error = RuntimeError("Custom error message")
+    with TestClient(app) as client:
+        response = client.get("/")
+        html = response.text
+        assert "Something went wrong" in html
+        assert "No logging info available" in html
+        assert "RuntimeError" in html
+        assert "Custom error message" in html
+
+
+def test_fallback_with_server():
+    config = {
+        "things": {
+            "thing1": "labthings_fastapi.example_things:MyThing",
+            "thing2": {
+                "class": "labthings_fastapi.example_things:MyThing",
+                "kwargs": {},
+            },
+        }
+    }
+    app.labthings_server = server_from_config(config)
+    with TestClient(app) as client:
+        response = client.get("/")
+        html = response.text
+        assert "Something went wrong" in html
+        assert "No logging info available" in html
+        assert "thing1/" in html
+        assert "thing2/" in html
+
+
+def test_fallback_with_log():
+    app.log_history = "Fake log conetent"
+    with TestClient(app) as client:
+        response = client.get("/")
+        html = response.text
+        assert "Something went wrong" in html
+        assert "No logging info available" not in html
+        assert "<p>Logging info</p>" in html
+        assert "Fake log conetent" in html

--- a/tests/test_server_cli.py
+++ b/tests/test_server_cli.py
@@ -131,6 +131,7 @@ def test_invalid_thing():
     with raises(ImportError):
         check_serve_from_cli(["-j", config_json])
 
+
 def test_fallback():
     """test the fallback option
 

--- a/tests/test_server_cli.py
+++ b/tests/test_server_cli.py
@@ -119,8 +119,8 @@ def test_serve_with_no_config():
         check_serve_from_cli([])
 
 
-def test_invalid_thing_and_fallback():
-    """Check it fails for invalid things, and test the fallback option"""
+def test_invalid_thing():
+    """Check it fails for invalid things"""
     config_json = json.dumps(
         {
             "things": {
@@ -130,8 +130,20 @@ def test_invalid_thing_and_fallback():
     )
     with raises(ImportError):
         check_serve_from_cli(["-j", config_json])
-    ## the line below should start a dummy server with an error page -
-    ## it terminates happily once the server starts.
+
+def test_fallback():
+    """test the fallback option
+
+    startd a dummy server with an error page -
+    it terminates once the server starts.
+    """
+    config_json = json.dumps(
+        {
+            "things": {
+                "broken": "labthings_fastapi.example_things:MissingThing",
+            }
+        }
+    )
     check_serve_from_cli(["-j", config_json, "--fallback"])
 
 


### PR DESCRIPTION
Adds more information to the fallback server:

* Display the traceback, but this isn't always too helpful
* Optionally pass log history for display

Screenshot with OFM server passing through logs:

![image](https://github.com/user-attachments/assets/4a18dbb3-ee46-4ff1-8dc4-68503571e508)
