### PR TITLE
Switch build system to hatch and add json files to sdist and wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "labthings-fastapi"
-version = "0.0.8"
+version = "0.0.9"
 authors = [
   { name="Richard Bowman", email="richard.bowman@cantab.net" },
 ]
@@ -39,8 +39,17 @@ server = [
 "Bug Tracker" = "https://github.com/rwb27/labthings-fastapi/issues"
 
 [build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "src"
+]
+artifacts = ["src/*.json"]
+
+[tool.hatch.build.targets.wheel]
+artifacts = ["src/*.json"]
 
 [tool.ruff]
 target-version = "py39"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ artifacts = ["src/*.json"]
 artifacts = ["src/*.json"]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 
 [tool.mypy]
 plugins = ["pydantic.mypy", "numpy.typing.mypy_plugin"]


### PR DESCRIPTION
This should be possible with setuptools but I followed their docs and it didn't work as I expected.

Closes #97 

Checking in the wheel (and the tarball) the only change is adding the json file:

![image](https://github.com/user-attachments/assets/a3b7bb7f-1c4a-43f7-bc76-418fc9817a86)
