### PR TITLE
Splitting out the generation of the argument parser for the CLI

### DIFF
--- a/src/labthings_fastapi/server/cli.py
+++ b/src/labthings_fastapi/server/cli.py
@@ -39,6 +39,7 @@ def get_default_parser():
 def parse_args(argv: Optional[list[str]] = None) -> Namespace:
     """Process command line arguments for the server"""
     parser = get_default_parser()
+    # Use parser to parse CLI arguments and return the namespace with attributes set.
     return parser.parse_args(argv)
 
 

--- a/src/labthings_fastapi/server/cli.py
+++ b/src/labthings_fastapi/server/cli.py
@@ -10,8 +10,12 @@ import uvicorn
 from . import ThingServer, server_from_config
 
 
-def parse_args(argv: Optional[list[str]] = None) -> Namespace:
-    """Process command line arguments for the server"""
+def get_default_parser():
+    """Return the default CLI parser for LabThings
+
+    This can be used instead of `parse_args` if more arguments are needed
+    """
+
     parser = ArgumentParser()
     parser.add_argument("-c", "--config", type=str, help="Path to configuration file")
     parser.add_argument("-j", "--json", type=str, help="Configuration as JSON string")
@@ -29,8 +33,13 @@ def parse_args(argv: Optional[list[str]] = None) -> Namespace:
         default=5000,
         help="Bind socket to this port. If 0, an available port will be picked.",
     )
-    args = parser.parse_args(argv)
-    return args
+    return parser
+
+
+def parse_args(argv: Optional[list[str]] = None) -> Namespace:
+    """Process command line arguments for the server"""
+    parser = get_default_parser()
+    return parser.parse_args(argv)
 
 
 def config_from_args(args: Namespace) -> dict:


### PR DESCRIPTION
The generation of the argument parser is now a seperate function from calling it. This allows downstream programs to add extra functionality to their argument parser if needed.