### PR TITLE
Exploring making persistent properties instead of settings

### DIFF
--- a/src/labthings_fastapi/decorators/__init__.py
+++ b/src/labthings_fastapi/decorators/__init__.py
@@ -91,6 +91,27 @@ def thing_property(func: Callable) -> PropertyDescriptor:
         getter=func,
     )
 
+def persistent_thing_property(func: Callable) -> PropertyDescriptor:
+    """Mark a method of a Thing as a Property
+
+    We replace the function with a `Descriptor` that's a
+    subclass of `PropertyDescriptor`
+
+    TODO: try https://stackoverflow.com/questions/54413434/type-hinting-with-descriptors
+    """
+
+    class PropertyDescriptorSubclass(PropertyDescriptor):
+        def __get__(self, obj, objtype=None):
+            return super().__get__(obj, objtype)
+
+    return PropertyDescriptorSubclass(
+        return_type(func),
+        readonly=True,
+        observable=False,
+        getter=func,
+        persistent=True,
+    )
+
 
 def fastapi_endpoint(method: HTTPMethod, path: Optional[str] = None, **kwargs):
     """Add a function to FastAPI as an endpoint"""

--- a/src/labthings_fastapi/server/__init__.py
+++ b/src/labthings_fastapi/server/__init__.py
@@ -18,6 +18,7 @@ from ..thing import Thing
 from ..thing_description.model import ThingDescription
 from ..dependencies.thing_server import _thing_servers
 from ..outputs.blob import BlobDataManager
+from ..utilities import class_attributes
 
 
 class ThingServer:
@@ -85,6 +86,10 @@ class ThingServer:
         thing._labthings_thing_settings = ThingSettings(
             os.path.join(settings_folder, "settings.json")
         )
+        for name, attribute in class_attributes(thing):
+            if hasattr(attribute, "property_affordance"):
+                if attribute.persistent:
+                    attribute.save_location = os.path.join(settings_folder, "settings.json")
         thing.attach_to_server(self, path)
 
     @asynccontextmanager


### PR DESCRIPTION
**This is very much an unfinished draft for discussion**

## Problems this is trying to solve:

* ThingSettings are not saving reliably
* ThingSettings are not obviously and explicitly defined
* ThingSettings require quite a bit of extra code to interact with them as a dictionary
* ThingSettings sometimes return a ReactiveDict to the API causes an error with Pydantic

## High level implementation details

**Summary**

This MR would make properties have an option to be persistent, saving to disk when the setter is called.

**A new decorator**

A new decorator `@persistent_thing_property` is created, this acts exactly as `@thing_property` except that it saves to disk. This could be `@thing_property(persistent=True)` except that making arguments for decorators is a bit messy, and making *optional* arguments is even messier and quite non-standard unless I have missed something.

**Add attributes to PropertyDescriptor**

Two attributes are added:
* `persistent` a boolean that sets whether the Property should save to disk
* `save_location` This is the save path (Optional!). It starts as `None`. If it is `None` saving would not happen, if it is set, saving would. Currently this just logs that it _should_ save:

![image](https://github.com/user-attachments/assets/3c1a907d-fa44-44ae-a335-a799c0e03e9f)

**Changes to `add_thing` on the server**

Check through each attribute using `class_attributes` utility function that already exists. If a property is found, then it is checked whether it is persistent. If it is the save location is added to the descriptors `save_location`.

*Not added yet!*
Read from disk and set the property from values on disk

## Issues to consider

* ***Directly updating the descriptor at runtime seems like bad thing to do to pass in the `save_location`. It is unclear to me whether there were two objects of the same class whether it would break. Ideas welcome.***
* Concurrency. Probably rather than just save directly in the descriptor, the server should pass some sort of class that controls the property files that can ensure that they are run sequentially.
* Whether the setter should warn/error if persistent and the save location is None. This would mean that we would need a 3rd state to say that the Thing was in the setup mode as the server will need to set the properties loaded from disk without raising the warnings/errors
