### PR TITLE
Expose key symbols at top level

### DIFF
--- a/src/labthings_fastapi/__init__.py
+++ b/src/labthings_fastapi/__init__.py
@@ -1,0 +1,5 @@
+from .thing import Thing
+from .descriptors import ThingProperty, ThingSetting
+from .decorators import (
+    thing_property, thing_setting, thing_action,
+)


### PR DESCRIPTION
Currently, there are lots of imports from quite deep within this library that should be easier to find. @julianstirling suggested adding a useful set of top-level objects to the top level `__init__` module, so that

```python
from labthings_fastapi.thing import Thing
from labthings_fastapi.descriptors import ThingProperty, ThingSetting
from labthings_fastapi.decorators import thing_action
```
could become

```python
from labthings_fastapi import Thing, ThingProperty, ThingSetting, thing_action
```

It might even become a helpful convention to `import labthings as lt` and then use `lt.Thing` etc.

This feels like it should be simple, and all the symbols above work just fine. However, I have run into problems in the past when I tried to do this (specifically for `labthings_fastapi.dependencies`) because of circular references. This might limit how many things can usefully be exposed at top level.

Also, at the moment there is one `labthings_fastapi` module that is both client and server. If `labthings_fastapi` is installed without the `server` extra, i.e. it's being used only as a client over HTTP, adding these top level imports will break it - because `labthings_fastapi.thing` has a hard dependency on `fastapi`, for example. I suspect the resolution to that is to split the package into a client and server module - but I'd welcome opinions on what makes most sense.

Depends on #110 (now merged)

Closes #99 
