### PR TITLE
Make server dependencies non-optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
   "typing_extensions",
   "anyio ~=4.0",
   "httpx",
+  "fastapi[all]>=0.115.0",
+  "zeroconf >=0.28.0",
 ]
 
 [project.optional-dependencies]
@@ -28,10 +30,6 @@ dev = [
   "mypy>=1.6.1, <2",
   "ruff>=0.1.3",
   "types-jsonschema",
-]
-server = [
-  "fastapi[all]>=0.115.0",
-  "zeroconf >=0.28.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Currently, a labthings client can be installed with `pip install labthings_fastapi` and the server is installed with `pip install labthings_fastapi[server]`. #121 makes it possible to import `Thing` from the top level namespace, which will fail if we don't have the optional `server` dependencies.

This PR makes the server dependencies non-optional. Doing so will fix some confusion, and stop client-only installs from being broken now that `Thing` can be imported at top level.

In the future, we should have a separate PyPI package for the client code. I think this will be clearer for people using it, avoid confusion for people needing server functionality, and help organise the code better.

Closes #120