### PR TITLE
Use type hints on properties instead of `model` argument

### DIFF
--- a/docs/source/quickstart/counter.py
+++ b/docs/source/quickstart/counter.py
@@ -22,8 +22,8 @@ class TestThing(lt.Thing):
             time.sleep(1)
             self.increment_counter()
 
-    counter = lt.ThingProperty(
-        model=int, initial_value=0, readonly=True, description="A pointless counter"
+    counter = lt.ThingProperty[int](
+        initial_value=0, readonly=True, description="A pointless counter"
     )
 
 

--- a/examples/counter.py
+++ b/examples/counter.py
@@ -23,8 +23,8 @@ class TestThing(lt.Thing):
             time.sleep(1)
             self.increment_counter()
 
-    counter = lt.ThingProperty(
-        model=int, initial_value=0, readonly=True, description="A pointless counter"
+    counter = lt.ThingProperty[int](
+        initial_value=0, readonly=True, description="A pointless counter"
     )
 
 

--- a/examples/demo_thing_server.py
+++ b/examples/demo_thing_server.py
@@ -58,12 +58,11 @@ class MyThing(lt.Thing):
             time.sleep(1)
             self.increment_counter()
 
-    counter = lt.ThingProperty(
-        model=int, initial_value=0, readonly=True, description="A pointless counter"
+    counter = lt.ThingProperty[int](
+        initial_value=0, readonly=True, description="A pointless counter"
     )
 
-    foo = lt.ThingProperty(
-        model=str,
+    foo = lt.ThingProperty[str](
         initial_value="Example",
         description="A pointless string for demo purposes.",
     )

--- a/examples/opencv_camera_server.py
+++ b/examples/opencv_camera_server.py
@@ -1,0 +1,292 @@
+import logging
+import threading
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse, StreamingResponse
+from labthings_fastapi.descriptors.property import ThingProperty
+from labthings_fastapi.thing import Thing
+from labthings_fastapi.decorators import thing_action, thing_property
+from labthings_fastapi.server import ThingServer
+from labthings_fastapi.file_manager import FileManagerDep
+from typing import Optional, AsyncContextManager
+from collections.abc import AsyncGenerator
+from functools import partial
+from dataclasses import dataclass
+from datetime import datetime
+from contextlib import asynccontextmanager
+import anyio
+from anyio.from_thread import BlockingPortal
+from threading import RLock
+import cv2 as cv
+
+logging.basicConfig(level=logging.INFO)
+
+
+@dataclass
+class RingbufferEntry:
+    """A single entry in a ringbuffer"""
+
+    frame: bytes
+    timestamp: datetime
+    index: int
+    readers: int = 0
+
+
+class MJPEGStreamResponse(StreamingResponse):
+    media_type = "multipart/x-mixed-replace; boundary=frame"
+
+    def __init__(self, gen: AsyncGenerator[bytes, None], status_code: int = 200):
+        """A StreamingResponse that streams an MJPEG stream
+
+        This response is initialised with an async generator that yields `bytes`
+        objects, each of which is a JPEG file. We add the --frame markers and mime
+        types that enable it to work in an `img` tag.
+
+        NB the `status_code` argument is used by FastAPI to set the status code of
+        the response in OpenAPI.
+        """
+        self.frame_async_generator = gen
+        StreamingResponse.__init__(
+            self,
+            self.mjpeg_async_generator(),
+            media_type=self.media_type,
+            status_code=status_code,
+        )
+
+    async def mjpeg_async_generator(self) -> AsyncGenerator[bytes, None]:
+        """A generator yielding an MJPEG stream"""
+        async for frame in self.frame_async_generator:
+            yield b"--frame\r\nContent-Type: image/jpeg\r\n\r\n"
+            yield frame
+            yield b"\r\n"
+
+
+class MJPEGStream:
+    def __init__(self, ringbuffer_size: int = 10):
+        self._lock = threading.Lock()
+        self.condition = anyio.Condition()
+        self._streaming = False
+        self.reset(ringbuffer_size=ringbuffer_size)
+
+    def reset(self, ringbuffer_size: Optional[int] = None):
+        """Reset the stream and optionally change the ringbuffer size"""
+        with self._lock:
+            self._streaming = True
+            n = ringbuffer_size or len(self._ringbuffer)
+            self._ringbuffer = [
+                RingbufferEntry(
+                    frame=b"",
+                    index=-1,
+                    timestamp=datetime.min,
+                )
+                for i in range(n)
+            ]
+            self.last_frame_i = -1
+
+    def stop(self):
+        """Stop the stream"""
+        with self._lock:
+            self._streaming = False
+
+    async def ringbuffer_entry(self, i: int) -> RingbufferEntry:
+        """Return the `i`th frame acquired by the camera"""
+        if i < 0:
+            raise ValueError("i must be >= 0")
+        if i < self.last_frame_i - len(self._ringbuffer) + 2:
+            raise ValueError("the ith frame has been overwritten")
+        if i > self.last_frame_i:
+            # TODO: await the ith frame
+            raise ValueError("the ith frame has not yet been acquired")
+        entry = self._ringbuffer[i % len(self._ringbuffer)]
+        if entry.index != i:
+            raise ValueError("the ith frame has been overwritten")
+        return entry
+
+    @asynccontextmanager
+    async def buffer_for_reading(self, i: int) -> AsyncContextManager[bytes]:
+        """Yields the ith frame as a bytes object"""
+        entry = await self.ringbuffer_entry(i)
+        try:
+            entry.readers += 1
+            yield entry.frame
+        finally:
+            entry.readers -= 1
+
+    async def next_frame(self) -> int:
+        """Wait for the next frame, and return its index"""
+        async with self.condition:
+            await self.condition.wait()
+            return self.last_frame_i
+
+    async def frame_async_generator(self) -> AsyncGenerator[bytes, None]:
+        """A generator that yields frames as bytes"""
+        while self._streaming:
+            try:
+                i = await self.next_frame()
+                async with self.buffer_for_reading(i) as frame:
+                    yield frame
+            except Exception as e:
+                logging.error(f"Error in stream: {e}, stream stopped")
+                return
+
+    async def mjpeg_stream_response(self) -> MJPEGStreamResponse:
+        """Return a StreamingResponse that streams an MJPEG stream"""
+        return MJPEGStreamResponse(self.frame_async_generator())
+
+    def add_frame(self, frame: bytes, portal: BlockingPortal):
+        """Return the next buffer in the ringbuffer to write to"""
+        with self._lock:
+            entry = self._ringbuffer[(self.last_frame_i + 1) % len(self._ringbuffer)]
+            if entry.readers > 0:
+                raise RuntimeError("Cannot write to ringbuffer while it is being read")
+            entry.timestamp = datetime.now()
+            entry.frame = frame
+            entry.index = self.last_frame_i + 1
+            portal.start_task_soon(self.notify_new_frame, entry.index)
+
+    async def notify_new_frame(self, i):
+        """Notify any waiting tasks that a new frame is available"""
+        async with self.condition:
+            self.last_frame_i = i
+            self.condition.notify_all()
+
+
+class MJPEGStreamDescriptor:
+    """A descriptor that returns a MJPEGStream object when accessed"""
+
+    def __init__(self, **kwargs):
+        self._kwargs = kwargs
+
+    def __set_name__(self, owner, name):
+        self.name = name
+
+    def __get__(self, obj, type=None) -> MJPEGStream:
+        """The value of the property
+
+        If `obj` is none (i.e. we are getting the attribute of the class),
+        we return the descriptor.
+
+        If no getter is set, we'll return either the initial value, or the value
+        from the object's __dict__, i.e. we behave like a variable.
+
+        If a getter is set, we will use it, unless the property is observable, at
+        which point the getter is only ever used once, to set the initial value.
+        """
+        if obj is None:
+            return self
+        try:
+            return obj.__dict__[self.name]
+        except KeyError:
+            obj.__dict__[self.name] = MJPEGStream(**self._kwargs)
+            return obj.__dict__[self.name]
+
+    async def viewer_page(self, url: str) -> HTMLResponse:
+        return HTMLResponse(f"<html><body><img src='{url}'></body></html>")
+
+    def add_to_fastapi(self, app: FastAPI, thing: Thing):
+        """Add the stream to the FastAPI app"""
+        app.get(
+            f"{thing.path}{self.name}",
+            response_class=MJPEGStreamResponse,
+        )(self.__get__(thing).mjpeg_stream_response)
+        app.get(
+            f"{thing.path}{self.name}/viewer",
+            response_class=HTMLResponse,
+        )(partial(self.viewer_page, f"{thing.path}{self.name}"))
+
+
+class OpenCVCamera(Thing):
+    """A Thing that represents an OpenCV camera"""
+
+    def __init__(self, device_index: int = 0):
+        self.device_index = device_index
+        self._stream_thread: Optional[threading.Thread] = None
+
+    def __enter__(self):
+        self._cap = cv.VideoCapture(self.device_index)
+        self._cap_lock = RLock()
+        if not self._cap.isOpened():
+            raise IOError(f"Cannot open camera with device index {self.device_index}")
+        self.start_streaming()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.stop_streaming()
+        self._cap.release()
+        del self._cap
+        del self._cap_lock
+
+    def start_streaming(self):
+        print("starting stream...")
+        if self._stream_thread is not None:
+            raise RuntimeError("Stream thread already running")
+        self._stream_thread = threading.Thread(target=self._stream_thread_fn)
+        self._continue_streaming = True
+        self._stream_thread.start()
+        print("started")
+
+    def stop_streaming(self):
+        print("stopping stream...")
+        if self._stream_thread is None:
+            raise RuntimeError("Stream thread not running")
+        self._continue_streaming = False
+        self.mjpeg_stream.stop()
+        print("waiting for stream to join")
+        self._stream_thread.join()
+        print("stream stopped.")
+        self._stream_thread = None
+
+    def _stream_thread_fn(self):
+        while self._continue_streaming:
+            with self._cap_lock:
+                ret, frame = self._cap.read()
+                if not ret:
+                    logging.error("Could not read frame from camera")
+                    continue
+            success, array = cv.imencode(".jpg", frame)
+            if success:
+                self.mjpeg_stream.add_frame(
+                    frame=array.tobytes(),
+                    portal=self._labthings_blocking_portal,
+                )
+                self.last_frame_index = self.mjpeg_stream.last_frame_i
+
+    @thing_action
+    def snap_image(self, file_manager: FileManagerDep) -> str:
+        """Acquire one image from the camera.
+
+        This action cannot run if the camera is in use by a background thread, for
+        example if a preview stream is running.
+        """
+        with self._cap_lock:
+            ret, frame = self._cap.read()
+            if not ret:
+                raise IOError("Could not read image from camera")
+            fpath = file_manager.path("image.jpg", rel="image")
+            cv.imwrite(fpath, frame)
+            return (
+                "image.jpg is available from the links property of this Invocation "
+                "(see ./files)"
+            )
+
+    @thing_property
+    def exposure(self) -> float:
+        with self._cap_lock:
+            return self._cap.get(cv.CAP_PROP_EXPOSURE)
+
+    @exposure.setter
+    def exposure(self, value):
+        with self._cap_lock:
+            self._cap.set(cv.CAP_PROP_EXPOSURE, value)
+
+    last_frame_index = ThingProperty[int](int, initial_value=-1)
+
+    mjpeg_stream = MJPEGStreamDescriptor(ringbuffer_size=10)
+
+
+thing_server = ThingServer()
+my_thing = OpenCVCamera()
+my_thing.validate_thing_description()
+thing_server.add_thing(my_thing, "/camera")
+
+app = thing_server.app

--- a/examples/picamera2_camera_server.py
+++ b/examples/picamera2_camera_server.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+import logging
+import time
+
+from pydantic import BaseModel, BeforeValidator
+
+from labthings_fastapi.descriptors.property import ThingProperty
+from labthings_fastapi.thing import Thing
+from labthings_fastapi.decorators import thing_action, thing_property
+from labthings_fastapi.server import ThingServer
+from labthings_fastapi.file_manager import FileManagerDep
+from typing import Annotated, Any, Iterator, Optional
+from contextlib import contextmanager
+from anyio.from_thread import BlockingPortal
+from threading import RLock
+import picamera2
+from picamera2 import Picamera2
+from picamera2.encoders import MJPEGEncoder, Quality
+from picamera2.outputs import Output
+from labthings_fastapi.outputs.mjpeg_stream import MJPEGStreamDescriptor, MJPEGStream
+from labthings_fastapi.utilities import get_blocking_portal
+
+
+logging.basicConfig(level=logging.INFO)
+
+
+class PicameraControl(ThingProperty):
+    def __init__(
+        self, control_name: str, model: type = float, description: Optional[str] = None
+    ):
+        """A property descriptor controlling a picamera control"""
+        ThingProperty.__init__(self, model, observable=False, description=description)
+        self.control_name = control_name
+        self._getter
+
+    def _getter(self, obj: StreamingPiCamera2):
+        print(f"getting {self.control_name} from {obj}")
+        with obj.picamera() as cam:
+            ret = cam.capture_metadata()[self.control_name]
+            print(f"Trying to return camera control {self.control_name} as `{ret}`")
+            return ret
+
+    def _setter(self, obj: StreamingPiCamera2, value: Any):
+        with obj.picamera() as cam:
+            setattr(cam.controls, self.control_name, value)
+
+
+class PicameraStreamOutput(Output):
+    """An Output class that sends frames to a stream"""
+
+    def __init__(self, stream: MJPEGStream, portal: BlockingPortal):
+        """Create an output that puts frames in an MJPEGStream
+
+        We need to pass the stream object, and also the blocking portal, because
+        new frame notifications happen in the anyio event loop and frames are
+        sent from a thread. The blocking portal enables thread-to-async
+        communication.
+        """
+        Output.__init__(self)
+        self.stream = stream
+        self.portal = portal
+
+    def outputframe(self, frame, _keyframe=True, _timestamp=None):
+        """Add a frame to the stream's ringbuffer"""
+        self.stream.add_frame(frame, self.portal)
+
+
+class SensorMode(BaseModel):
+    unpacked: str
+    bit_depth: int
+    size: tuple[int, int]
+    fps: float
+    crop_limits: tuple[int, int, int, int]
+    exposure_limits: tuple[Optional[int], Optional[int], Optional[int]]
+    format: Annotated[str, BeforeValidator(repr)]
+
+
+class StreamingPiCamera2(Thing):
+    """A Thing that represents an OpenCV camera"""
+
+    def __init__(self, device_index: int = 0):
+        self.device_index = device_index
+        self.camera_configs: dict[str, dict] = {}
+
+    stream_resolution = ThingProperty[tuple[int, int]](
+        initial_value=(1640, 1232),
+        description="Resolution to use for the MJPEG stream",
+    )
+    image_resolution = ThingProperty[tuple[int, int]](
+        initial_value=(3280, 2464),
+        description="Resolution to use for still images (by default)",
+    )
+    mjpeg_bitrate = ThingProperty[int](
+        initial_value=0, description="Bitrate for MJPEG stream (best left at 0)"
+    )
+    stream_active = ThingProperty[bool](
+        initial_value=False,
+        description="Whether the MJPEG stream is active",
+        observable=True,
+    )
+    mjpeg_stream = MJPEGStreamDescriptor()
+    analogue_gain = PicameraControl("AnalogueGain", float)
+    colour_gains = PicameraControl("ColourGains", tuple[float, float])
+    colour_correction_matrix = PicameraControl(
+        "ColourCorrectionMatrix",
+        tuple[float, float, float, float, float, float, float, float, float],
+    )
+    exposure_time = PicameraControl(
+        "ExposureTime", int, description="The exposure time in microseconds"
+    )
+    exposure_time = PicameraControl(
+        "ExposureTime", int, description="The exposure time in microseconds"
+    )
+    sensor_modes = ThingProperty[list[SensorMode]](readonly=True, getter=list)
+
+    def __enter__(self):
+        self._picamera = picamera2.Picamera2(camera_num=self.device_index)
+        self._picamera_lock = RLock()
+        self.populate_sensor_modes()
+        self.start_streaming()
+        return self
+
+    @contextmanager
+    def picamera(self) -> Iterator[Picamera2]:
+        with self._picamera_lock:
+            yield self._picamera
+
+    def populate_sensor_modes(self):
+        with self.picamera() as cam:
+            self.sensor_modes = cam.sensor_modes
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.stop_streaming()
+        with self.picamera() as cam:
+            cam.close()
+        del self._picamera
+
+    def start_streaming(self) -> None:
+        """
+        Start the MJPEG stream
+
+        Sets the camera resolution to the video/stream resolution, and starts recording
+        if the stream should be active.
+        """
+        with self.picamera() as picam:
+            # TODO: Filip: can we use the lores output to keep preview stream going
+            # while recording? According to picamera2 docs 4.2.1.6 this should work
+            try:
+                if picam.started:
+                    picam.stop()
+                if picam.encoder is not None and picam.encoder.running:
+                    picam.encoder.stop()
+                stream_config = picam.create_video_configuration(
+                    main={"size": self.stream_resolution},
+                    # colour_space=ColorSpace.Rec709(),
+                )
+                picam.configure(stream_config)
+                logging.info("Starting picamera MJPEG stream...")
+                picam.start_recording(
+                    MJPEGEncoder(
+                        self.mjpeg_bitrate if self.mjpeg_bitrate > 0 else None,
+                    ),
+                    PicameraStreamOutput(
+                        self.mjpeg_stream,
+                        get_blocking_portal(self),
+                    ),
+                    Quality.HIGH,  # TODO: use provided quality
+                )
+            except Exception as e:
+                logging.info("Error while starting preview:")
+                logging.exception(e)
+            else:
+                self.stream_active = True
+                logging.debug(
+                    "Started MJPEG stream at %s on port %s", self.stream_resolution, 1
+                )
+
+    def stop_streaming(self) -> None:
+        """
+        Stop the MJPEG stream
+        """
+        with self.picamera() as picam:
+            try:
+                picam.stop_recording()
+            except Exception as e:
+                logging.info("Stopping recording failed")
+                logging.exception(e)
+            else:
+                self.stream_active = False
+                self.mjpeg_stream.stop()
+                logging.info(
+                    f"Stopped MJPEG stream. Switching to {self.image_resolution}."
+                )
+
+            # Increase the resolution for taking an image
+            time.sleep(
+                0.2
+            )  # Sprinkled a sleep to prevent camera getting confused by rapid commands
+
+    @thing_action
+    def snap_image(self, file_manager: FileManagerDep) -> str:
+        """Acquire one image from the camera.
+
+        This action cannot run if the camera is in use by a background thread, for
+        example if a preview stream is running.
+        """
+        raise NotImplementedError
+
+    @thing_property
+    def exposure(self) -> float:
+        raise NotImplementedError()
+
+    @exposure.setter
+    def exposure(self, value):
+        raise NotImplementedError()
+
+    last_frame_index = [int](initial_value=-1)
+
+    mjpeg_stream = MJPEGStreamDescriptor(ringbuffer_size=10)
+
+
+thing_server = ThingServer()
+my_thing = StreamingPiCamera2()
+my_thing.validate_thing_description()
+thing_server.add_thing(my_thing, "/camera")
+
+app = thing_server.app

--- a/src/labthings_fastapi/decorators/__init__.py
+++ b/src/labthings_fastapi/decorators/__init__.py
@@ -33,7 +33,7 @@ not supported at this time.
 """
 
 from functools import wraps, partial
-from typing import Optional, Callable
+from typing import Optional, Callable, TypeVar, TYPE_CHECKING
 from ..descriptors import (
     ActionDescriptor,
     ThingProperty,
@@ -42,6 +42,10 @@ from ..descriptors import (
     HTTPMethod,
 )
 from ..utilities.introspection import return_type
+
+
+if TYPE_CHECKING:
+    from ..thing import Thing
 
 
 def mark_thing_action(func: Callable, **kwargs) -> ActionDescriptor:
@@ -72,7 +76,17 @@ def thing_action(func: Optional[Callable] = None, **kwargs):
         return partial(mark_thing_action, **kwargs)
 
 
-def thing_property(func: Callable) -> ThingProperty:
+Value = TypeVar("Value")
+
+
+def thing_property(
+    func: Callable[
+        [
+            Thing,
+        ],
+        Value,
+    ],
+) -> ThingProperty[Value]:
     """Mark a method of a Thing as a LabThings Property
 
     This should be used as a decorator with a getter and a setter
@@ -92,7 +106,14 @@ def thing_property(func: Callable) -> ThingProperty:
     )
 
 
-def thing_setting(func: Callable) -> ThingSetting:
+def thing_setting(
+    func: Callable[
+        [
+            Thing,
+        ],
+        Value,
+    ],
+) -> ThingSetting[Value]:
     """Mark a method of a Thing as a LabThings Setting.
 
     A setting is a property that persists between runs.

--- a/src/labthings_fastapi/decorators/__init__.py
+++ b/src/labthings_fastapi/decorators/__init__.py
@@ -33,7 +33,7 @@ not supported at this time.
 """
 
 from functools import wraps, partial
-from typing import Optional, Callable, TypeVar, TYPE_CHECKING
+from typing import Optional, Callable, TypeVar
 from ..descriptors import (
     ActionDescriptor,
     ThingProperty,
@@ -42,10 +42,6 @@ from ..descriptors import (
     HTTPMethod,
 )
 from ..utilities.introspection import return_type
-
-
-if TYPE_CHECKING:
-    from ..thing import Thing
 
 
 def mark_thing_action(func: Callable, **kwargs) -> ActionDescriptor:
@@ -79,14 +75,7 @@ def thing_action(func: Optional[Callable] = None, **kwargs):
 Value = TypeVar("Value")
 
 
-def thing_property(
-    func: Callable[
-        [
-            Thing,
-        ],
-        Value,
-    ],
-) -> ThingProperty[Value]:
+def thing_property(func: Callable[..., Value]) -> ThingProperty[Value]:
     """Mark a method of a Thing as a LabThings Property
 
     This should be used as a decorator with a getter and a setter
@@ -106,14 +95,7 @@ def thing_property(
     )
 
 
-def thing_setting(
-    func: Callable[
-        [
-            Thing,
-        ],
-        Value,
-    ],
-) -> ThingSetting[Value]:
+def thing_setting(func: Callable[..., Value]) -> ThingSetting[Value]:
     """Mark a method of a Thing as a LabThings Setting.
 
     A setting is a property that persists between runs.

--- a/src/labthings_fastapi/descriptors/property.py
+++ b/src/labthings_fastapi/descriptors/property.py
@@ -179,7 +179,9 @@ class ThingProperty(Generic[Value]):
         1. As a type argument on the property itself, e.g. `BaseThingProperty[int]`
         2. As a type annotation on the class, e.g. `my_property: int = BaseThingProperty`
         3. As a type annotation on the getter method, e.g. `@BaseThingProperty\n def my_property(self) -> int: ...`
-        4. As an explicitly set model argument, e.g. `BaseThingProperty(model=int)`
+
+        There is a model argument, e.g. `BaseThingProperty(model=int)` but this is no longer
+        supported and will raise an error.
 
         All of these are checked, and an error is raised if any of them are inconsistent.
         If no type is specified, an error is raised.
@@ -226,6 +228,10 @@ class ThingProperty(Generic[Value]):
             raise MissingTypeError(
                 f"Property '{name}' on '{owner}' is missing a type annotation. "
                 "Please provide a type annotation ."
+            )
+        if len(value_types) == 1 and "model_argument" in value_types:
+            raise MissingTypeError(
+                f"Property '{name}' on '{owner}' specifies `model` but is not type annotated."
             )
         print(
             f"Initializing property '{name}' on '{owner}', {value_types}."
@@ -428,7 +434,7 @@ class ThingProperty(Generic[Value]):
         return self
 
 
-class ThingSetting(ThingProperty):
+class ThingSetting(ThingProperty[Value], Generic[Value]):
     """A setting can be accessed via the HTTP API and is persistent between sessions
 
     A ThingSetting is a ThingProperty with extra functionality for triggering

--- a/src/labthings_fastapi/descriptors/property.py
+++ b/src/labthings_fastapi/descriptors/property.py
@@ -140,7 +140,10 @@ class ThingProperty(Generic[Value]):
         :param initial_value: The initial value of the property. If this is set,
             the property must not have a getter, and should behave like a variable.
         :param readonly: If True, the property cannot be set via the HTTP API.
-        :param observable: If True, the property can be observed for changes.
+        :param observable: If True, the property can be observed for changes via
+            websockets. This causes the setter to run code in the async event loop
+            that will notify a list of subscribers each time the property is set.
+            Currently, only websockets can be used to observe properties.
         :param description: A description of the property, used in the API documentation.
             LabThings will attempt to take this from the docstring if not supplied.
         :param title: A human-readable title for the property, used in the API

--- a/src/labthings_fastapi/example_things/__init__.py
+++ b/src/labthings_fastapi/example_things/__init__.py
@@ -73,12 +73,11 @@ class MyThing(Thing):
             time.sleep(delay)
             self.increment_counter()
 
-    counter = ThingProperty(
-        model=int, initial_value=0, readonly=True, description="A pointless counter"
+    counter = ThingProperty[int](
+        initial_value=0, readonly=True, description="A pointless counter"
     )
 
-    foo = ThingProperty(
-        model=str,
+    foo = ThingProperty[str](
         initial_value="Example",
         description="A pointless string for demo purposes.",
     )
@@ -103,7 +102,7 @@ class ThingWithBrokenAffordances(Thing):
         raise RuntimeError("This is a broken action")
 
     @thing_property
-    def broken_property(self):
+    def broken_property(self) -> bool:
         """A property that raises an exception"""
         raise RuntimeError("This is a broken property")
 

--- a/tests/test_action_cancel.py
+++ b/tests/test_action_cancel.py
@@ -11,9 +11,8 @@ import time
 
 class CancellableCountingThing(lt.Thing):
     counter = lt.ThingProperty[int](initial_value=0, observable=False)
-    check = lt.ThingProperty(
-        bool,
-        False,
+    check = lt.ThingProperty[bool](
+        initial_value=False,
         observable=False,
         description=(
             "This variable is used to check that the action can detect a cancel event "

--- a/tests/test_action_cancel.py
+++ b/tests/test_action_cancel.py
@@ -10,7 +10,7 @@ import time
 
 
 class CancellableCountingThing(lt.Thing):
-    counter = lt.ThingProperty(int, 0, observable=False)
+    counter = lt.ThingProperty[int](initial_value=0, observable=False)
     check = lt.ThingProperty(
         bool,
         False,

--- a/tests/test_action_manager.py
+++ b/tests/test_action_manager.py
@@ -13,7 +13,7 @@ class TestThing(lt.Thing):
         """Increment the counter"""
         self.counter += 1
 
-    counter = lt.ThingProperty(
+    counter = lt.ThingProperty[int](
         model=int, initial_value=0, readonly=True, description="A pointless counter"
     )
 

--- a/tests/test_dependency_metadata.py
+++ b/tests/test_dependency_metadata.py
@@ -14,7 +14,7 @@ class ThingOne(lt.Thing):
         self._a = 0
 
     @lt.thing_property
-    def a(self):
+    def a(self) -> int:
         return self._a
 
     @a.setter

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -68,21 +68,29 @@ def test_instantiation_with_type():
     assert issubclass(BasicThing.prop.model, BaseModel)
 
 
+def exception_is_or_is_caused_by(err: Exception, cls: type[Exception]):
+    return isinstance(err, cls) or isinstance(err.__cause__, cls)
+
+
 def test_instantiation_with_type_and_model():
     """If a model is specified, we check it matches the inferred type."""
 
     class BasicThing(lt.Thing):
         prop = lt.ThingProperty[bool](model=bool, initial_value=False)
 
-    with pytest.raises(MismatchedTypeError):
+    with pytest.raises(Exception) as e:
 
         class InvalidThing(lt.Thing):
             prop = lt.ThingProperty[bool](model=int, initial_value=False)
 
-    with pytest.raises(MissingTypeError):
+    assert exception_is_or_is_caused_by(e.value, MismatchedTypeError)
+
+    with pytest.raises(Exception) as e:
 
         class InvalidThing(lt.Thing):
             prop = lt.ThingProperty(model=bool, initial_value=False)
+
+    assert exception_is_or_is_caused_by(e.value, MissingTypeError)
 
 
 def test_missing_default():

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -63,7 +63,7 @@ def test_instantiation_with_type():
     """
 
     class BasicThing(lt.Thing):
-        prop = lt.ThingProperty[bool](default=False)
+        prop = lt.ThingProperty[bool](initial_value=False)
 
     assert issubclass(BasicThing.prop.model, BaseModel)
 
@@ -72,17 +72,17 @@ def test_instantiation_with_type_and_model():
     """If a model is specified, we check it matches the inferred type."""
 
     class BasicThing(lt.Thing):
-        prop = lt.ThingProperty[bool](model=bool, default=False)
+        prop = lt.ThingProperty[bool](model=bool, initial_value=False)
 
     with pytest.raises(MismatchedTypeError):
 
         class InvalidThing(lt.Thing):
-            prop = lt.ThingProperty[bool](model=int, default=False)
+            prop = lt.ThingProperty[bool](model=int, initial_value=False)
 
     with pytest.raises(MissingTypeError):
 
         class InvalidThing(lt.Thing):
-            prop = lt.ThingProperty(model=bool, default=False)
+            prop = lt.ThingProperty(model=bool, initial_value=False)
 
 
 def test_missing_default():
@@ -97,7 +97,7 @@ def test_annotation_on_class():
     """Test that a type annotation on the attribute is picked up."""
 
     class BasicThing(lt.Thing):
-        prop: bool = lt.ThingProperty(default=False)
+        prop: bool = lt.ThingProperty(initial_value=False)
 
     assert isinstance(BasicThing.prop, lt.ThingProperty)
     assert BasicThing.prop._value_type is bool
@@ -111,7 +111,7 @@ def test_overspecified_default():
             def get_prop(self) -> bool:
                 return False
 
-            prop = lt.ThingProperty[bool](default=False, getter=get_prop)
+            prop = lt.ThingProperty[bool](initial_value=False, getter=get_prop)
 
 
 def test_instantiation_with_model():
@@ -120,7 +120,7 @@ def test_instantiation_with_model():
         b: float = 2.0
 
     class BasicThing(lt.Thing):
-        prop = lt.ThingProperty(MyModel, MyModel())
+        prop = lt.ThingProperty[MyModel](initial_value=MyModel())
 
     assert BasicThing.prop.model is MyModel
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -48,10 +48,14 @@ def test_instantiation_with_type():
     Check the internal model (data type) of the ThingSetting descriptor is a BaseModel
 
     To send the data over HTTP LabThings-FastAPI uses Pydantic models to describe data
-    types.
+    types. Note that the model is not created until the property is assigned to a
+    `Thing`, as it happens in `__set_name__` of the `ThingProperty` descriptor.
     """
-    prop = lt.ThingProperty(bool, False)
-    assert issubclass(prop.model, BaseModel)
+
+    class BasicThing(lt.Thing):
+        prop = lt.ThingProperty(bool, False)
+
+    assert issubclass(BasicThing.prop.model, BaseModel)
 
 
 def test_instantiation_with_model():
@@ -59,8 +63,10 @@ def test_instantiation_with_model():
         a: int = 1
         b: float = 2.0
 
-    prop = lt.ThingProperty(MyModel, MyModel())
-    assert prop.model is MyModel
+    class BasicThing(lt.Thing):
+        prop = lt.ThingProperty(MyModel, MyModel())
+
+    assert BasicThing.prop.model is MyModel
 
 
 def test_property_get_and_set():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -11,9 +11,9 @@ import labthings_fastapi as lt
 
 
 class TestThing(lt.Thing):
-    boolsetting = lt.ThingSetting(bool, False, description="A boolean setting")
-    stringsetting = lt.ThingSetting(str, "foo", description="A string setting")
-    dictsetting = lt.ThingSetting(
+    boolsetting = lt.ThingSetting[bool](bool, False, description="A boolean setting")
+    stringsetting = lt.ThingSetting[str](str, "foo", description="A string setting")
+    dictsetting = lt.ThingSetting[dict](
         dict, {"a": 1, "b": 2}, description="A dictionary setting"
     )
 

--- a/tests/test_thing_lifecycle.py
+++ b/tests/test_thing_lifecycle.py
@@ -3,7 +3,9 @@ from fastapi.testclient import TestClient
 
 
 class TestThing(lt.Thing):
-    alive = lt.ThingProperty(bool, False, description="Is the thing alive?")
+    alive = lt.ThingProperty[bool](
+        initial_value=False, description="Is the thing alive?"
+    )
 
     def __enter__(self):
         print("setting up TestThing from __enter__")


### PR DESCRIPTION
This branch builds on @julianstirling's type hint branch to eliminate the `model` argument from properties. 

```python
class ExampleThing(Thing):
    old_prop = ThingProperty(model=str | None, initial_value="Default)
    new_prop = ThingProperty[str | None](initial_value="Default")

    @thing_property
    def my_property(self) -> str | None:
        return "Default"
```

Both forms are now properly type hinted, tests with mypy to ensure inferred types are correct will happen in due course.

The tests are updated to use the new syntax, and `ThingProperty` will raise an exception if type hints are missing. Currently, specifying a `model` argument and no type hints will raise an error - this behaviour could be changed, but would result in less good type hints if it's allowed.

I've left the `model` argument as a double-check, if present it will be compared to the type hint and raise an error if it differs. We will probably remove it in due course.