### PR TITLE
Nicer formatting of fallback, returns 206 (partial) instead of 500

### DIFF
--- a/src/labthings_fastapi/server/fallback.py
+++ b/src/labthings_fastapi/server/fallback.py
@@ -43,6 +43,7 @@ pre {
     white-space: pre-wrap;
     overflow-wrap: anywhere;
 }
+</style>
 </html>
 """
 

--- a/src/labthings_fastapi/server/fallback.py
+++ b/src/labthings_fastapi/server/fallback.py
@@ -38,13 +38,18 @@ ERROR_PAGE = """
     <pre>{{traceback}}</pre>
     {{logginginfo}}
 </body>
+<style>
+pre {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
 </html>
 """
 
 
 @app.get("/")
 async def root():
-    error_message = f"{app.labthings_error!r}"
+    error_message = f"{app.labthings_error}"
     # use traceback.format_exception to get full traceback as list
     # this ends in newlines, but needs joining to be a single string
     error_w_trace = "".join(format_exception(app.labthings_error))
@@ -65,7 +70,7 @@ async def root():
         logging_info = f"    <p>Logging info</p>\n    <pre>{app.log_history}</pre>"
 
     content = content.replace("{{logginginfo}}", logging_info)
-    return HTMLResponse(content=content, status_code=500)
+    return HTMLResponse(content=content, status_code=206)
 
 
 @app.get("/{path:path}")

--- a/src/labthings_fastapi/server/fallback.py
+++ b/src/labthings_fastapi/server/fallback.py
@@ -71,7 +71,7 @@ async def root():
         logging_info = f"    <p>Logging info</p>\n    <pre>{app.log_history}</pre>"
 
     content = content.replace("{{logginginfo}}", logging_info)
-    return HTMLResponse(content=content, status_code=206)
+    return HTMLResponse(content=content, status_code=218)
 
 
 @app.get("/{path:path}")


### PR DESCRIPTION
Style changes:

- Remove raw tag from error message, allowing the Python exception \n character to create a new line, improving readability
- Add text wrapping to `<pre>` tag, preventing horizontal scroll bars

![image](https://github.com/user-attachments/assets/6b0300c9-0419-428e-954f-66bc2f2fe83d)

![image](https://github.com/user-attachments/assets/545732f5-ab26-4cc3-b894-9b4cdd1c4f7e)

Changing status code to ~~206 (partial success)~~ **reading about 206, it's partial success if the client only requests partial, which doesn't apply here**

Code to 218 (this is fine) until someone finds a better one

Reason is that Connect won't open a tab returning a 5xx message, so we can't see the fallback messages in Connect. This will also require getting rid of Connect's version checking that we're connecting with a v2 microscope...

Before

![image](https://github.com/user-attachments/assets/8ba66b15-e9f0-4e55-a42a-db481b62d72e)

After

![image](https://github.com/user-attachments/assets/7a24b30b-7820-4233-8b9b-36133c858ed1)
