### PR TITLE
Test MJPEGStream

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -81,6 +81,8 @@ orjson==3.10.15
     # via fastapi
 packaging==24.2
     # via pytest
+pillow==11.3.0
+    # via labthings-fastapi (pyproject.toml)
 pluggy==1.5.0
     # via pytest
 pydantic==2.10.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
   "mypy>=1.6.1, <2",
   "ruff>=0.1.3",
   "types-jsonschema",
+  "Pillow",
 ]
 
 [project.urls]

--- a/src/labthings_fastapi/outputs/mjpeg_stream.py
+++ b/src/labthings_fastapi/outputs/mjpeg_stream.py
@@ -204,7 +204,10 @@ class MJPEGStream:
             portal.start_task_soon(self.notify_new_frame, entry.index)
 
     async def notify_new_frame(self, i: int) -> None:
-        """Notify any waiting tasks that a new frame is available"""
+        """Notify any waiting tasks that a new frame is available.
+
+        :param i: The number of the frame (which counts up since the server starts)
+        """
         async with self.condition:
             self.last_frame_i = i
             self.condition.notify_all()

--- a/tests/test_mjpeg_stream.py
+++ b/tests/test_mjpeg_stream.py
@@ -1,0 +1,66 @@
+import io
+import threading
+import time
+from PIL import Image
+from fastapi.testclient import TestClient
+import labthings_fastapi as lt
+
+
+class Telly(lt.Thing):
+    _stream_thread: threading.Thread
+    _streaming: bool = False
+    framerate: float = 1000
+
+    stream = lt.outputs.MJPEGStreamDescriptor()
+
+    def __enter__(self):
+        self._streaming = True
+        self._stream_thread = threading.Thread(target=self._make_images)
+        self._stream_thread.start()
+
+    def __exit__(self, exc_t, exc_v, exc_tb):
+        self._streaming = False
+        self._stream_thread.join()
+
+    def _make_images(self):
+        """Stream a series of solid colours"""
+        colours = ["#F00", "#0F0", "#00F"]
+        jpegs = []
+        for c in colours:
+            image = Image.new("RGB", (10, 10), c)
+            dest = io.BytesIO()
+            image.save(dest, "jpeg")
+            jpegs.append(dest.getvalue())
+
+        i = -1
+        start_time = time.time()
+        while self._streaming:
+            i = (i + 1) % len(jpegs)
+            print(f"sending frame {i}")
+            self.stream.add_frame(jpegs[i], self._labthings_blocking_portal)
+            time.sleep(1 / self.framerate)
+
+            if time.time() - start_time > 10:
+                break
+        print("stopped sending frames")
+        self._streaming = False
+
+
+def test_mjpeg_stream():
+    server = lt.ThingServer()
+    telly = Telly()
+    server.add_thing(telly, "telly")
+    with TestClient(server.app) as client:
+        with client.stream("GET", "/telly/stream", timeout=0.1) as stream:
+            stream.raise_for_status()
+            received = 0
+            for b in stream.iter_bytes():
+                received += 1
+                print(f"Got packet {received}")
+                assert b.startswith(b"--frame")
+                if received > 5:
+                    break
+
+
+if __name__ == "__main__":
+    test_mjpeg_stream()


### PR DESCRIPTION
The `MJPEGStream` output was the single biggest bit of untested code. There is now a very basic test that makes sure it sends a response with at least one frame separator in it.

In doing this, it was necessary to add code to cleanly close the stream. This has changed the signature of the `stop` method, which may require calling code to be updated.

The `TestClient` we use to test without serving on HTTP does not support streaming: this means we get all the frames at once, which limits exactly what can be tested. Adding the code to cleanly stop the stream is important, as otherwise the TestClient would hang.