### PR TITLE
Bump version number to v0.0.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "labthings-fastapi"
-version = "0.0.9"
+version = "0.0.10"
 authors = [
   { name="Richard Bowman", email="richard.bowman@cantab.net" },
 ]


### PR DESCRIPTION
Just bumping the version number for release. There is no CHANGELOG in the repo currently we are doing all change logging in the release notes.