### PR TITLE
Add BlobIOContextDep to ActionDescriptor.list_invocations so context vars are available

### DIFF
--- a/src/labthings_fastapi/actions/__init__.py
+++ b/src/labthings_fastapi/actions/__init__.py
@@ -131,7 +131,14 @@ class Invocation(Thread):
 
     @property
     def output(self) -> Any:
-        """Return value of the Action. If the Action is still running, returns None."""
+        """Return value of the Action. If the Action is still running, returns None.
+
+        :raise NoBlobManagerError: If this is called in a context where the blob
+            manager context variables are not available. This stops errors being raised
+            later once the blob is returned and tries to serialise. If the errors
+            happen during serialisation the stack-trace will not clearly identify
+            the route with the missing dependency.
+        """
         try:
             blobdata_to_url_ctx.get()
         except LookupError as e:

--- a/src/labthings_fastapi/descriptors/action.py
+++ b/src/labthings_fastapi/descriptors/action.py
@@ -339,7 +339,9 @@ class ActionDescriptor:
             ),
             summary=f"All invocations of {self.name}.",
         )
-        def list_invocations(action_manager: ActionManagerContextDep):
+        def list_invocations(
+            action_manager: ActionManagerContextDep, _blob_manager: BlobIOContextDep
+        ):
             return action_manager.list_invocations(self, thing)
 
     def action_affordance(


### PR DESCRIPTION
This is a quick fix to #142

It is my understanding that ActionDescriptor.list_invocations would serialise the blob url, but has no BlobIOContextDep dependency. Why it is being called now and not before isn't totally clear to me. But, it seems to fix the error for now.

A more longterm fix where the arguments needed are provided explicitly would be good.