### PR TITLE
Fix read-only properties in `DirectThingClient`

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -55,10 +55,6 @@ email-validator==2.2.0
     # via
     #   fastapi
     #   pydantic
-exceptiongroup==1.3.0
-    # via
-    #   anyio
-    #   pytest
 fastapi==0.116.1
     # via labthings-fastapi (pyproject.toml)
 fastapi-cli==0.0.8
@@ -170,7 +166,10 @@ pytest==7.4.4
     # via
     #   labthings-fastapi (pyproject.toml)
     #   pytest-cov
+    #   pytest-mock
 pytest-cov==6.2.1
+    # via labthings-fastapi (pyproject.toml)
+pytest-mock==3.14.1
     # via labthings-fastapi (pyproject.toml)
 python-dotenv==1.1.1
     # via
@@ -242,14 +241,6 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 starlette==0.47.1
     # via fastapi
-tomli==2.2.1
-    # via
-    #   coverage
-    #   flake8-pyproject
-    #   mypy
-    #   pydoclint
-    #   pytest
-    #   sphinx
 typer==0.16.0
     # via
     #   fastapi-cli
@@ -260,20 +251,16 @@ typing-extensions==4.14.1
     # via
     #   labthings-fastapi (pyproject.toml)
     #   anyio
-    #   astroid
-    #   exceptiongroup
     #   fastapi
     #   mypy
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
     #   referencing
-    #   rich
     #   rich-toolkit
     #   starlette
     #   typer
     #   typing-inspection
-    #   uvicorn
 typing-inspection==0.4.1
     # via pydantic-settings
 ujson==5.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 dev = [
   "pytest>=7.4.0, <8",
   "pytest-cov",
+  "pytest-mock",
   "mypy>=1.6.1, <2",
   "ruff>=0.1.3",
   "types-jsonschema",

--- a/src/labthings_fastapi/client/in_server.py
+++ b/src/labthings_fastapi/client/in_server.py
@@ -124,12 +124,18 @@ def property_descriptor(
     def __set__(self, obj: DirectThingClient, value: Any):
         setattr(obj._wrapped_thing, self.name, value)
 
+    def set_readonly(self, obj: DirectThingClient, value: Any):
+        raise AttributeError("This property is read-only.")
+
     if readable:
         __get__.__annotations__["return"] = model
         P.__get__ = __get__  # type: ignore[attr-defined]
     if writeable:
         __set__.__annotations__["value"] = model
         P.__set__ = __set__  # type: ignore[attr-defined]
+    else:
+        set_readonly.__annotations__["value"] = model
+        P.__set__ = set_readonly  # type: ignore[attr-defined]
     if description:
         P.__doc__ = description
     return P()

--- a/tests/test_directthingclient.py
+++ b/tests/test_directthingclient.py
@@ -1,0 +1,128 @@
+"""Test the DirectThingClient class.
+
+This module tests inter-Thing interactions. It does not yet test exhaustively,
+and has been added primarily to fix #165.
+"""
+
+from fastapi.testclient import TestClient
+import pytest
+import labthings_fastapi as lt
+from labthings_fastapi.client.in_server import direct_thing_client_class
+from .temp_client import poll_task
+
+
+class Counter(lt.Thing):
+    ACTION_ONE_RESULT = "Action one result!"
+
+    @lt.thing_action
+    def increment(self) -> str:
+        """An action that takes no arguments"""
+        return self.increment_internal()
+
+    def increment_internal(self) -> str:
+        """An action that increments the counter."""
+        self.count += self.step
+        return self.ACTION_ONE_RESULT
+
+    step: int = lt.property(default=1)
+    count: int = lt.property(default=0, readonly=True)
+
+
+@pytest.fixture
+def counter_client(mocker):
+    counter = Counter()
+    counter._labthings_blocking_portal = mocker.Mock(["start_task_soon"])
+
+    CounterClient = direct_thing_client_class(Counter, "/counter")
+
+    class StandaloneCounterClient(CounterClient):
+        def __init__(self, wrapped):
+            self._dependencies = {}
+            self._request = mocker.Mock()
+            self._wrapped_thing = wrapped
+
+    return StandaloneCounterClient(counter)
+
+
+def test_readwrite_property(counter_client):
+    """Test a read/write property works as expected."""
+    counter_client.step = 2
+    assert counter_client.step == 2
+
+
+def test_readonly_property(counter_client):
+    """Test a read/write property works as expected."""
+    assert counter_client.count == 0
+    with pytest.raises(AttributeError):
+        counter_client.count = 10
+
+
+def test_action(counter_client):
+    """Test we can run an action."""
+    assert counter_client.count == 0
+    counter_client.increment()
+    assert counter_client.count == 1
+
+
+def test_method(counter_client):
+    """Methods that are not decorated as actions should be missing."""
+    with pytest.raises(AttributeError):
+        counter_client.increment_internal()
+    # Just to double-check the line above isn't a typo...
+    counter_client._wrapped_thing.increment_internal()
+
+
+CounterDep = lt.deps.direct_thing_client_dependency(Counter, "/counter/")
+RawCounterDep = lt.deps.raw_thing_dependency(Counter)
+
+
+class Controller(lt.Thing):
+    @lt.thing_action
+    def count_in_twos(self, counter: CounterDep) -> str:
+        """An action that needs a Counter and uses its affordances."""
+        counter.step = 2
+        assert counter.count == 0
+        counter.increment()
+        assert counter.count == 2
+        return "success"
+
+    @lt.thing_action
+    def count_internal(self, counter: CounterDep) -> str:
+        """Another action that tries to access local-only attributes."""
+        try:
+            counter.increment_internal()
+            raise AssertionError("Expected error was not raised!")
+        except AttributeError:
+            # pytest.raises seems to hang.
+            pass
+        try:
+            counter.count = 4
+            raise AssertionError("Expected error was not raised!")
+        except AttributeError:
+            # pytest.raises seems to hang.
+            pass
+        return "success"
+
+    @lt.thing_action
+    def count_raw(self, counter: RawCounterDep) -> str:
+        counter.count = 0
+        counter.step = -1
+        counter.increment_internal()
+        assert counter.count == -1
+        return "success"
+
+
+@pytest.mark.parametrize("action", ["count_in_twos", "count_internal", "count_raw"])
+def test_directthingclient_in_server(action):
+    """Test that a Thing can depend on another Thing
+
+    This uses the internal thing client mechanism.
+    """
+    server = lt.ThingServer()
+    server.add_thing(Counter(), "/counter")
+    server.add_thing(Controller(), "/controller")
+    with TestClient(server.app) as client:
+        r = client.post(f"/controller/{action}")
+        invocation = poll_task(client, r.json())
+        assert invocation["status"] == "completed"
+        assert invocation["output"] == "success"

--- a/tests/test_directthingclient.py
+++ b/tests/test_directthingclient.py
@@ -7,7 +7,7 @@ and has been added primarily to fix #165.
 from fastapi.testclient import TestClient
 import pytest
 import labthings_fastapi as lt
-from lt.deps import DirectThingClient, direct_thing_client_class
+from labthings_fastapi.deps import DirectThingClient, direct_thing_client_class
 from .temp_client import poll_task
 
 

--- a/tests/test_directthingclient.py
+++ b/tests/test_directthingclient.py
@@ -7,7 +7,7 @@ and has been added primarily to fix #165.
 from fastapi.testclient import TestClient
 import pytest
 import labthings_fastapi as lt
-from labthings_fastapi.client.in_server import direct_thing_client_class
+from lt.deps import DirectThingClient, direct_thing_client_class
 from .temp_client import poll_task
 
 
@@ -29,7 +29,17 @@ class Counter(lt.Thing):
 
 
 @pytest.fixture
-def counter_client(mocker):
+def counter_client(mocker) -> DirectThingClient:
+    r"""Instantiate a Counter and wrap it in a DirectThingClient.
+
+    In order to make this work without a server, ``DirectThingClient`` is
+    subclassed, and ``__init__`` is overridden.
+    This could be done with ``mocker`` but it would be more verbose and
+    less clear.
+
+    :param mocker: the mocker test fixture from ``pytest-mock``\ .
+    :returns: a ``DirectThingClient`` subclass wrapping a ``Counter``\ .
+    """
     counter = Counter()
     counter._labthings_blocking_portal = mocker.Mock(["start_task_soon"])
 
@@ -42,6 +52,62 @@ def counter_client(mocker):
             self._wrapped_thing = wrapped
 
     return StandaloneCounterClient(counter)
+
+
+CounterDep = lt.deps.direct_thing_client_dependency(Counter, "/counter/")
+RawCounterDep = lt.deps.raw_thing_dependency(Counter)
+
+
+class Controller(lt.Thing):
+    """Controller is used to test a real DirectThingClient in a server.
+
+    This is used by ``test_directthingclient_in_server`` to verify the
+    client works as expected when created normally, rather than by mocking
+    the server.
+    """
+
+    @lt.thing_action
+    def count_in_twos(self, counter: CounterDep) -> str:
+        """An action that needs a Counter and uses its affordances.
+
+        This only uses methods that are part of the HTTP API, so all
+        of these commands should work.
+        """
+        counter.step = 2
+        assert counter.count == 0
+        counter.increment()
+        assert counter.count == 2
+        return "success"
+
+    @lt.thing_action
+    def count_internal(self, counter: CounterDep) -> str:
+        """An action that tries to access local-only attributes.
+
+        This previously used `pytest.raises` but that caused the test
+        to hang, most likely because this will run in a background thread.
+        """
+        try:
+            counter.increment_internal()
+            raise AssertionError("Expected error was not raised!")
+        except AttributeError:
+            # pytest.raises seems to hang.
+            pass
+        try:
+            counter.count = 4
+            raise AssertionError("Expected error was not raised!")
+        except AttributeError:
+            # pytest.raises seems to hang.
+            pass
+        return "success"
+
+    @lt.thing_action
+    def count_raw(self, counter: RawCounterDep) -> str:
+        """Increment the counter using a method that is not an Action."""
+        counter.count = 0
+        counter.step = -1
+        counter.increment_internal()
+        assert counter.count == -1
+        return "success"
 
 
 def test_readwrite_property(counter_client):
@@ -70,46 +136,6 @@ def test_method(counter_client):
         counter_client.increment_internal()
     # Just to double-check the line above isn't a typo...
     counter_client._wrapped_thing.increment_internal()
-
-
-CounterDep = lt.deps.direct_thing_client_dependency(Counter, "/counter/")
-RawCounterDep = lt.deps.raw_thing_dependency(Counter)
-
-
-class Controller(lt.Thing):
-    @lt.thing_action
-    def count_in_twos(self, counter: CounterDep) -> str:
-        """An action that needs a Counter and uses its affordances."""
-        counter.step = 2
-        assert counter.count == 0
-        counter.increment()
-        assert counter.count == 2
-        return "success"
-
-    @lt.thing_action
-    def count_internal(self, counter: CounterDep) -> str:
-        """Another action that tries to access local-only attributes."""
-        try:
-            counter.increment_internal()
-            raise AssertionError("Expected error was not raised!")
-        except AttributeError:
-            # pytest.raises seems to hang.
-            pass
-        try:
-            counter.count = 4
-            raise AssertionError("Expected error was not raised!")
-        except AttributeError:
-            # pytest.raises seems to hang.
-            pass
-        return "success"
-
-    @lt.thing_action
-    def count_raw(self, counter: RawCounterDep) -> str:
-        counter.count = 0
-        counter.step = -1
-        counter.increment_internal()
-        assert counter.count == -1
-        return "success"
 
 
 @pytest.mark.parametrize("action", ["count_in_twos", "count_internal", "count_raw"])

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -112,7 +112,11 @@ class ClientThing(lt.Thing):
         client: TestThingClientDep,
         val: bool,
     ):
-        """Attempt to set a setting with a DirectThingClient."""
+        """Attempt to set a setting with a DirectThingClient.
+
+        This should fail with an error, as it's not writeable from a
+        DirectThingClient.
+        """
         client.localonly_boolsetting = val
 
     @lt.thing_action
@@ -130,7 +134,11 @@ class ClientThing(lt.Thing):
         test_thing: TestThingDep,
         val: bool,
     ):
-        """Attempt to set a setting directly."""
+        """Attempt to set a setting directly.
+
+        This should work, even though the setting is read-only from clients.
+        Using a raw thing dependency bypasses that restriction.
+        """
         test_thing.localonly_boolsetting = val
 
 
@@ -291,7 +299,7 @@ def test_readonly_setting(thing, client_thing, server, endpoint, value, method):
             # The setting is not changed (that's tested later), but the action
             # does complete. It should fail with an error, but this is expected
             # behaviour - see #165.
-            assert invocation["status"] == "completed"
+            assert invocation["status"] == "error"
 
         # Check the setting hasn't changed over HTTP
         r = client.get(f"/thing/{endpoint}")


### PR DESCRIPTION
Currently, read-only properties in `DirectThingClient` are "non-data descriptors" (#165).

This PR introduces a unit test to verify read-only properties work as expected (an `AttributeError` is raised on write). It then fixes the behaviour so that the test passes, and fixes `test_settings` (which assumed the old, broken behaviour).

Closes #165 