### PR TITLE
Raise better errors in observe_property, and test them.

### DIFF
--- a/src/labthings_fastapi/exceptions.py
+++ b/src/labthings_fastapi/exceptions.py
@@ -26,3 +26,13 @@ class ReadOnlyPropertyError(AttributeError):
     No setter has been defined for this `.FunctionalProperty`, so
     it may not be written to.
     """
+
+
+class PropertyNotObservableError(RuntimeError):
+    """The property is not observable.
+
+    This exception is raised when `.Thing.observe_property` is called with a
+    property that is not observable. Currently, only data properties are
+    observable: functional properties (using a getter/setter) may not be
+    observed.
+    """

--- a/src/labthings_fastapi/thing.py
+++ b/src/labthings_fastapi/thing.py
@@ -21,7 +21,7 @@ from anyio.to_thread import run_sync
 
 from pydantic import BaseModel
 
-from .properties import DataProperty, BaseSetting
+from .properties import BaseProperty, DataProperty, BaseSetting
 from .descriptors import ActionDescriptor
 from .thing_description._model import ThingDescription, NoSecurityScheme
 from .utilities import class_attributes
@@ -349,8 +349,14 @@ class Thing:
         :raise KeyError: if the requested name is not defined on this Thing.
         """
         prop = getattr(self.__class__, property_name)
-        if not isinstance(prop, DataProperty):
+        if not isinstance(prop, BaseProperty):
             raise KeyError(f"{property_name} is not a LabThings Property")
+        if not isinstance(prop, DataProperty):
+            raise TypeError(
+                f"{property_name} is not observable. Only data properties are "
+                "observable. This error is often encountered if you try to "
+                "observe a functional property (one with a getter/setter)."
+            )
         prop._observers_set(self).add(stream)
 
     def observe_action(self, action_name: str, stream: ObjectSendStream) -> None:

--- a/src/labthings_fastapi/thing.py
+++ b/src/labthings_fastapi/thing.py
@@ -28,6 +28,7 @@ from .utilities import class_attributes
 from .thing_description import validation
 from .utilities.introspection import get_summary, get_docstring
 from .websockets import websocket_endpoint
+from .exceptions import PropertyNotObservableError
 
 
 if TYPE_CHECKING:
@@ -352,11 +353,7 @@ class Thing:
         if not isinstance(prop, BaseProperty):
             raise KeyError(f"{property_name} is not a LabThings Property")
         if not isinstance(prop, DataProperty):
-            raise TypeError(
-                f"{property_name} is not observable. Only data properties are "
-                "observable. This error is often encountered if you try to "
-                "observe a functional property (one with a getter/setter)."
-            )
+            raise PropertyNotObservableError(f"{property_name} is not observable.")
         prop._observers_set(self).add(stream)
 
     def observe_action(self, action_name: str, stream: ObjectSendStream) -> None:

--- a/src/labthings_fastapi/thing.py
+++ b/src/labthings_fastapi/thing.py
@@ -348,6 +348,7 @@ class Thing:
         :param stream: the stream used to send events.
 
         :raise KeyError: if the requested name is not defined on this Thing.
+        :raise PropertyNotObservableError: if the property is not observable.
         """
         prop = getattr(self.__class__, property_name)
         if not isinstance(prop, BaseProperty):

--- a/src/labthings_fastapi/thing.py
+++ b/src/labthings_fastapi/thing.py
@@ -350,7 +350,7 @@ class Thing:
         :raise KeyError: if the requested name is not defined on this Thing.
         :raise PropertyNotObservableError: if the property is not observable.
         """
-        prop = getattr(self.__class__, property_name)
+        prop = getattr(self.__class__, property_name, None)
         if not isinstance(prop, BaseProperty):
             raise KeyError(f"{property_name} is not a LabThings Property")
         if not isinstance(prop, DataProperty):
@@ -365,7 +365,7 @@ class Thing:
 
         :raise KeyError: if the requested name is not defined on this Thing.
         """
-        action = getattr(self.__class__, action_name)
+        action = getattr(self.__class__, action_name, None)
         if not isinstance(action, ActionDescriptor):
             raise KeyError(f"{action_name} is not an LabThings Action")
         observers = action._observers_set(self)

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,36 +1,16 @@
 from fastapi.testclient import TestClient
-from labthings_fastapi.example_things import MyThing
 import pytest
 import labthings_fastapi as lt
 from labthings_fastapi.exceptions import PropertyNotObservableError
 
 
-@pytest.fixture
-def my_thing():
-    return MyThing()
-
-
-@pytest.fixture
-def server(my_thing):
-    server = lt.ThingServer()
-    server.add_thing(my_thing, "/my_thing")
-    return server
-
-
-def test_websocket_observeproperty(server):
-    with TestClient(server.app) as client:
-        with client.websocket_connect("/my_thing/ws") as ws:
-            ws.send_json(
-                {"messageType": "addPropertyObservation", "data": {"foo": True}}
-            )
-            test_str = "Abcdef"
-            client.put("/my_thing/foo", json=test_str)
-            message = ws.receive_json(mode="text")
-            assert message["data"]["foo"] == test_str
-            ws.close(1000)
-
-
 class ThingWithProperties(lt.Thing):
+    """A Thing with various different properties and actions.
+
+    This is used by the earlier tests, ensuring properties may
+    be observed.
+    """
+
     dataprop: int = lt.property(default=0)
     non_property: int = 0
 
@@ -38,7 +18,7 @@ class ThingWithProperties(lt.Thing):
     def funcprop(self) -> int:
         return 0
 
-    @lt.property
+    @funcprop.setter
     def set_funcprop(self, val: int) -> None:
         pass
 
@@ -48,134 +28,163 @@ class ThingWithProperties(lt.Thing):
         self.dataprop += 1
 
 
-def test_observing_dataprop(mocker):
+@pytest.fixture
+def thing():
+    """Instantiate and return a test Thing."""
+    return ThingWithProperties()
+
+
+@pytest.fixture
+def server(thing):
+    """Create a server, and add a MyThing test Thing to it."""
+    server = lt.ThingServer()
+    server.add_thing(thing, "/thing")
+    return server
+
+
+@pytest.fixture
+def client(server):
+    """Yield a TestClient connected to the server."""
+    with TestClient(server.app) as client:
+        yield client
+
+
+@pytest.fixture
+def ws(client):
+    """Yield a websocket connection to a server hosting a MyThing().
+
+    This ensures the websocket is properly closed after the test, and
+    avoids lots of indent levels.
+    """
+    with client.websocket_connect("/thing/ws") as ws:
+        try:
+            yield ws
+        finally:
+            ws.close(1000)
+            pass
+
+
+def test_observing_dataprop(thing, mocker):
     """Check `observe_property` is OK on a data property.
 
     This doesn't check the observation works, because we don't
     have an event loop. It just checks the call doesn't raise
     an error.
     """
-    thing = ThingWithProperties()
     thing.observe_property("dataprop", mocker.Mock())
 
 
-def test_observing_dataprop_with_ws():
-    """Observe a data property with a websocket, and check it works."""
-    server = lt.ThingServer()
-    server.add_thing(ThingWithProperties(), "/thing")
-    with TestClient(server.app) as client:
-        with client.websocket_connect("/thing/ws") as ws:
-            ws.send_json(
-                {"messageType": "addPropertyObservation", "data": {"dataprop": True}}
-            )
-            client.put("/thing/dataprop", json=1)
-            message = ws.receive_json(mode="text")
-            assert message["data"]["dataprop"] == 1
-            ws.close(1000)
-
-
-def test_observing_funcprop(mocker):
+@pytest.mark.parametrize(
+    argnames=["name", "exception"],
+    argvalues=[
+        ("funcprop", PropertyNotObservableError),
+        ("non_property", KeyError),
+        ("increment_dataprop", KeyError),
+        ("missing", KeyError),
+    ],
+)
+def test_observing_errors(thing, mocker, name, exception):
     """Check errors are raised if we observe an unsuitable property."""
-    thing = ThingWithProperties()
-    with pytest.raises(PropertyNotObservableError):
-        thing.observe_property("funcprop", mocker.Mock())
+    with pytest.raises(exception):
+        thing.observe_property(name, mocker.Mock())
 
 
-def test_observing_funcprop_with_ws():
-    """Try to observe a functional property with a websocket.
+def test_observing_dataprop_with_ws(client, ws):
+    """Observe a data property with a websocket.
+
+    This tests the property's value gets notified when it is
+    set via PUT requests or via an action.
+    """
+    # Observe the property.
+    ws.send_json(
+        {
+            "messageType": "addPropertyObservation",
+            "data": {"dataprop": True},
+        }
+    )
+    for val in [1, 10, 0]:
+        # Set the property's value.
+        client.put("/thing/dataprop", json=val)
+        # Receive the message and check it's as expected.
+        message = ws.receive_json(mode="text")
+        assert message["messageType"] == "propertyStatus"
+        assert message["data"]["dataprop"] == val
+    # Increment the value with an action
+    client.post("/thing/increment_dataprop")
+    message = ws.receive_json(mode="text")
+    assert message["messageType"] == "propertyStatus"
+    assert message["data"]["dataprop"] == 1
+
+
+@pytest.mark.parametrize(
+    argnames=["name", "title", "status"],
+    argvalues=[
+        ("funcprop", "Not Observable", "403"),
+        ("non_property", "Not Found", "404"),
+        ("increment_dataprop", "Not Found", "404"),
+        ("missing", "Not Found", "404"),
+    ],
+)
+def test_observing_dataprop_error_with_ws(ws, name, title, status):
+    """Try to observe a functional/missing property with a websocket.
 
     This should fail: functional properties are not observable.
     """
-    server = lt.ThingServer()
-    server.add_thing(ThingWithProperties(), "/thing")
-    with TestClient(server.app) as client:
-        with client.websocket_connect("/thing/ws") as ws:
-            ws.send_json(
-                {"messageType": "addPropertyObservation", "data": {"funcprop": True}}
-            )
-            message = ws.receive_json(mode="text")
-            assert message["error"]["title"] == "Not Observable"
-            ws.close(1000)
+    # Observe the property.
+    ws.send_json(
+        {
+            "messageType": "addPropertyObservation",
+            "data": {name: True},
+        }
+    )
+    # Receive the message and check for the error.
+    message = ws.receive_json(mode="text")
+    assert message["error"]["title"] == title
+    assert message["error"]["status"] == status
 
 
-def test_observing_missing_prop(mocker):
-    """Check observing a non-existent property raises an error."""
-    thing = ThingWithProperties()
-    with pytest.raises(AttributeError):
-        thing.observe_property("missing_property", mocker.Mock())
-
-
-def test_observing_not_prop(mocker):
-    """Check observing an attribute that's not a property raises an error."""
-    thing = ThingWithProperties()
-    with pytest.raises(KeyError):
-        thing.observe_property("non_property", mocker.Mock())
-
-
-def test_observing_action(mocker):
+def test_observing_action(thing, mocker):
     """Check observing an action is successful."""
-    thing = ThingWithProperties()
     thing.observe_action("increment_dataprop", mocker.Mock())
 
 
-def test_observing_not_action(mocker):
+def test_observing_action_error(thing, mocker):
     """Check observing an attribute that's not an action raises an error."""
-    thing = ThingWithProperties()
     with pytest.raises(KeyError):
         thing.observe_action("non_property", mocker.Mock())
 
 
-def test_websocket_observeproperty_counter(server):
-    with TestClient(server.app) as client:
-        with client.websocket_connect("/my_thing/ws") as ws:
-            ws.send_json(
-                {"messageType": "addPropertyObservation", "data": {"counter": True}}
-            )
-            # Trigger the increment_counter action to change the counter value
-            client.post("/my_thing/increment_counter")
-
-            # Receive the message from the WebSocket
-            message = ws.receive_json(mode="text")
-            assert (
-                message["data"]["counter"] == 1
-            )  # Expect the counter to be 1 after increment
-            ws.close(1000)
-            my_thing.counter = 0  # Set counter back to 0
-
-
-def handle_websocket_messages(message):
-    if (
-        message["messageType"] == "actionStatus"
-        and message["data"]["status"] == "completed"
-    ):
-        return True
-    return False
+def test_observing_action_with_ws(client, ws):
+    """Observe an action with a websocket, checking the status changes correctly."""
+    # Observe the property.
+    ws.send_json(
+        {
+            "messageType": "addActionObservation",
+            "data": {"increment_dataprop": True},
+        }
+    )
+    # Invoke the action (via HTTP)
+    client.post("/thing/increment_dataprop")
+    # We should see the status go through the expected sequence
+    for expected_status in ["pending", "running", "completed"]:
+        message = ws.receive_json(mode="text")
+        assert message["messageType"] == "actionStatus"
+        assert message["data"]["status"] == expected_status
 
 
-def test_websocket_observeaction(server, my_thing):
-    with TestClient(server.app) as client:
-        with client.websocket_connect("/my_thing/ws") as ws:
-            ws.send_json(
-                {"messageType": "addPropertyObservation", "data": {"counter": True}}
-            )
-            ws.send_json(
-                {
-                    "messageType": "addActionObservation",
-                    "data": {"slowly_increase_counter": True},
-                }
-            )
+def test_observing_action_error_with_ws(ws):
+    """Try to observe something that's not an action, as an action.
 
-            # Trigger the slowly_increase_counter action
-            client.post("/my_thing/slowly_increase_counter", json={"delay": 0})
-
-            # Listen for WebSocket messages and check for the completed action
-            action_completed = False
-            while not action_completed:
-                message = ws.receive_json()
-                print(f"Received message: {message}")
-
-                action_completed = handle_websocket_messages(message)
-                if action_completed:
-                    assert my_thing.counter == 60
-
-            my_thing.counter = 0  # Set counter back to 0
+    This should fail: observeAction should only work on actions.
+    """
+    # Observe the property.
+    ws.send_json(
+        {
+            "messageType": "addActionObservation",
+            "data": {"non_property": True},
+        }
+    )
+    # Receive the message and check for the error.
+    message = ws.receive_json(mode="text")
+    assert message["error"]["title"] == "Not Found"
+    assert message["error"]["status"] == "404"

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -82,11 +82,14 @@ def ws(client):
 def test_observing_dataprop(thing, mocker):
     """Check `observe_property` is OK on a data property.
 
-    This doesn't check the observation works, because we don't
-    have an event loop. It just checks the call doesn't raise
-    an error.
+    This checks that something is added to the set of observers.
+    We don't check for events, as there's no event loop: this is
+    tested in `test_observing_dataprop_with_ws` below.
     """
-    thing.observe_property("dataprop", mocker.Mock())
+    observers_set = ThingWithProperties.dataprop._observers_set(thing)
+    fake_observer = mocker.Mock()
+    thing.observe_property("dataprop", fake_observer)
+    assert fake_observer in observers_set
 
 
 @pytest.mark.parametrize(

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -162,8 +162,15 @@ def test_observing_dataprop_error_with_ws(ws, name, title, status):
 
 
 def test_observing_action(thing, mocker):
-    """Check observing an action is successful."""
-    thing.observe_action("increment_dataprop", mocker.Mock())
+    """Check observing an action is successful.
+
+    This verifies we've added an observer to the set, but doesn't test for
+    notifications: that would require an event loop.
+    """
+    observers_set = ThingWithProperties.increment_dataprop._observers_set(thing)
+    fake_observer = mocker.Mock()
+    thing.observe_action("increment_dataprop", fake_observer)
+    assert fake_observer in observers_set
 
 
 def test_observing_action_error(thing, mocker):

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -84,7 +84,6 @@ def ws(client):
             yield ws
         finally:
             ws.close(1000)
-            pass
 
 
 def test_observing_dataprop(thing, mocker):

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -32,6 +32,7 @@ def test_websocket_observeproperty(server):
 
 class ThingWithProperties(lt.Thing):
     dataprop: int = lt.property(default=0)
+    non_property: int = 0
 
     @lt.property
     def funcprop(self) -> int:
@@ -40,6 +41,11 @@ class ThingWithProperties(lt.Thing):
     @lt.property
     def set_funcprop(self, val: int) -> None:
         pass
+
+    @lt.thing_action
+    def increment_dataprop(self):
+        """Increment the data property."""
+        self.dataprop += 1
 
 
 def test_observing_dataprop(mocker):
@@ -97,6 +103,26 @@ def test_observing_missing_prop(mocker):
     thing = ThingWithProperties()
     with pytest.raises(AttributeError):
         thing.observe_property("missing_property", mocker.Mock())
+
+
+def test_observing_not_prop(mocker):
+    """Check observing an attribute that's not a property raises an error."""
+    thing = ThingWithProperties()
+    with pytest.raises(KeyError):
+        thing.observe_property("non_property", mocker.Mock())
+
+
+def test_observing_action(mocker):
+    """Check observing an action is successful."""
+    thing = ThingWithProperties()
+    thing.observe_action("increment_dataprop", mocker.Mock())
+
+
+def test_observing_not_action(mocker):
+    """Check observing an attribute that's not an action raises an error."""
+    thing = ThingWithProperties()
+    with pytest.raises(KeyError):
+        thing.observe_action("non_property", mocker.Mock())
 
 
 def test_websocket_observeproperty_counter(server):

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,7 +1,8 @@
-import labthings_fastapi as lt
 from fastapi.testclient import TestClient
 from labthings_fastapi.example_things import MyThing
 import pytest
+import labthings_fastapi as lt
+from labthings_fastapi.exceptions import PropertyNotObservableError
 
 
 @pytest.fixture
@@ -70,7 +71,7 @@ def test_observing_dataprop_with_ws():
 def test_observing_funcprop(mocker):
     """Check errors are raised if we observe an unsuitable property."""
     thing = ThingWithProperties()
-    with pytest.raises(TypeError):
+    with pytest.raises(PropertyNotObservableError):
         thing.observe_property("funcprop", mocker.Mock())
 
 
@@ -87,7 +88,7 @@ def test_observing_funcprop_with_ws():
                 {"messageType": "addPropertyObservation", "data": {"funcprop": True}}
             )
             message = ws.receive_json(mode="text")
-            assert message["data"]["dataprop"] == 1
+            assert message["error"]["title"] == "Not Observable"
             ws.close(1000)
 
 


### PR DESCRIPTION
This raises a helpful error if observe_property is called with an argument that isn't a DataProperty. Usually, this will be a functional property, which isn't observable.

To-do before merging:

- [x] Handle errors gracefully in the websocket endpoint.

Closes #169 