### PR TITLE
Test decorated actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,10 +74,7 @@ jobs:
           path: ./coverage.lcov
       
       - name: Analyse with MyPy
-        run: mypy src
-      
-      - name: Type tests with MyPy
-        run: mypy --warn-unused-ignores typing_tests
+        run: mypy
 
   test-with-unpinned-deps:
     runs-on: ubuntu-latest
@@ -105,7 +102,7 @@ jobs:
       
       - name: Analyse with MyPy
         if: success() || failure()
-        run: mypy src
+        run: mypy
 
       - name: Test with pytest
         if: success() || failure()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,12 @@ property-decorators = [
 ]
 
 [tool.mypy]
+files = ["src/", "typing_tests/"]
 plugins = ["pydantic.mypy"]
+disallow_untyped_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+warn_unused_ignores = true
 
 
 [tool.flake8]

--- a/src/labthings_fastapi/actions/__init__.py
+++ b/src/labthings_fastapi/actions/__init__.py
@@ -255,7 +255,7 @@ class Invocation(Thread):
         # which thinks we are calling ActionDescriptor.__get__.
         action: ActionDescriptor = self.action  # type: ignore[call-overload]
         try:
-            action.emit_changed_event(self.thing, str(self._status))
+            action.emit_changed_event(self.thing, self._status.value)
 
             # Capture just this thread's log messages
             handler = DequeLogHandler(dest=self._log)
@@ -269,7 +269,7 @@ class Invocation(Thread):
             with self._status_lock:
                 self._status = InvocationStatus.RUNNING
                 self._start_time = datetime.datetime.now()
-                action.emit_changed_event(self.thing, str(self._status))
+                action.emit_changed_event(self.thing, self._status.value)
 
             # The next line actually runs the action.
             ret = action.__get__(thing)(**kwargs, **self.dependencies)
@@ -277,12 +277,12 @@ class Invocation(Thread):
             with self._status_lock:
                 self._return_value = ret
                 self._status = InvocationStatus.COMPLETED
-                action.emit_changed_event(self.thing, str(self._status))
+                action.emit_changed_event(self.thing, self._status.value)
         except InvocationCancelledError:
             logger.info(f"Invocation {self.id} was cancelled.")
             with self._status_lock:
                 self._status = InvocationStatus.CANCELLED
-                action.emit_changed_event(self.thing, str(self._status))
+                action.emit_changed_event(self.thing, self._status.value)
         except Exception as e:  # skipcq: PYL-W0703
             # First log
             if isinstance(e, InvocationError):
@@ -294,7 +294,7 @@ class Invocation(Thread):
             with self._status_lock:
                 self._status = InvocationStatus.ERROR
                 self._exception = e
-                action.emit_changed_event(self.thing, str(self._status))
+                action.emit_changed_event(self.thing, self._status.value)
         finally:
             with self._status_lock:
                 self._end_time = datetime.datetime.now()

--- a/src/labthings_fastapi/client/__init__.py
+++ b/src/labthings_fastapi/client/__init__.py
@@ -148,7 +148,7 @@ class ThingClient:
         r.raise_for_status()
         return r.json()
 
-    def set_property(self, path: str, value: Any):
+    def set_property(self, path: str, value: Any) -> None:
         """Make a PUT request to set the value of a property.
 
         :param path: the URI of the ``getproperty`` endpoint, relative
@@ -159,7 +159,7 @@ class ThingClient:
         r = self.client.put(urljoin(self.path, path), json=value)
         r.raise_for_status()
 
-    def invoke_action(self, path: str, **kwargs):
+    def invoke_action(self, path: str, **kwargs: Any) -> Any:
         r"""Invoke an action on the Thing.
 
         This method will make the initial POST request to invoke an action,
@@ -180,8 +180,9 @@ class ThingClient:
         :raise RuntimeError: is raised if the action does not complete successfully.
         """
         for k in kwargs.keys():
-            if isinstance(kwargs[k], ClientBlobOutput):
-                kwargs[k] = {"href": kwargs[k].href, "media_type": kwargs[k].media_type}
+            value = kwargs[k]
+            if isinstance(value, ClientBlobOutput):
+                kwargs[k] = {"href": value.href, "media_type": value.media_type}
         r = self.client.post(urljoin(self.path, path), json=kwargs)
         r.raise_for_status()
         invocation = poll_invocation(self.client, r.json())
@@ -270,7 +271,9 @@ class ThingClient:
 class PropertyClientDescriptor:
     """A base class for properties on `.ThingClient` objects."""
 
-    pass
+    name: str
+    type: type | BaseModel
+    path: str
 
 
 def property_descriptor(
@@ -312,10 +315,10 @@ def property_descriptor(
     if readable:
 
         def __get__(
-            self,
+            self: PropertyClientDescriptor,
             obj: Optional[ThingClient] = None,
             _objtype: Optional[type[ThingClient]] = None,
-        ):
+        ) -> Any:
             if obj is None:
                 return self
             return obj.get_property(self.name)
@@ -324,7 +327,9 @@ def property_descriptor(
         P.__get__ = __get__  # type: ignore[attr-defined]
     if writeable:
 
-        def __set__(self, obj: ThingClient, value: Any):
+        def __set__(
+            self: PropertyClientDescriptor, obj: ThingClient, value: Any
+        ) -> None:
             obj.set_property(self.name, value)
 
         __set__.__annotations__["value"] = model
@@ -349,7 +354,7 @@ def add_action(cls: type[ThingClient], action_name: str, action: dict) -> None:
         format.
     """
 
-    def action_method(self, **kwargs):
+    def action_method(self: ThingClient, **kwargs: Any) -> Any:
         return self.invoke_action(action_name, **kwargs)
 
     if "output" in action and "type" in action["output"]:
@@ -359,7 +364,7 @@ def add_action(cls: type[ThingClient], action_name: str, action: dict) -> None:
     setattr(cls, action_name, action_method)
 
 
-def add_property(cls: type[ThingClient], property_name: str, property: dict):
+def add_property(cls: type[ThingClient], property_name: str, property: dict) -> None:
     """Add a property to a ThingClient subclass.
 
     A descriptor will be added to the provided class that makes the

--- a/src/labthings_fastapi/client/in_server.py
+++ b/src/labthings_fastapi/client/in_server.py
@@ -277,7 +277,7 @@ def direct_thing_client_class(
 
     def init_proxy(
         self: DirectThingClient, request: Request, **dependencies: Mapping[str, Any]
-    ):
+    ) -> None:
         r"""Initialise a DirectThingClient (this docstring will be replaced).
 
         :param self: The DirectThingClient instance we're initialising.

--- a/src/labthings_fastapi/client/in_server.py
+++ b/src/labthings_fastapi/client/in_server.py
@@ -113,18 +113,22 @@ def property_descriptor(
         path = property_path or property_name
 
     def __get__(
-        self,
+        self: PropertyClientDescriptor,
         obj: Optional[DirectThingClient] = None,
         _objtype: Optional[type[DirectThingClient]] = None,
-    ):
+    ) -> Any:
         if obj is None:
             return self
         return getattr(obj._wrapped_thing, self.name)
 
-    def __set__(self, obj: DirectThingClient, value: Any):
+    def __set__(
+        self: PropertyClientDescriptor, obj: DirectThingClient, value: Any
+    ) -> None:
         setattr(obj._wrapped_thing, self.name, value)
 
-    def set_readonly(self, obj: DirectThingClient, value: Any):
+    def set_readonly(
+        self: PropertyClientDescriptor, obj: DirectThingClient, value: Any
+    ) -> None:
         raise AttributeError("This property is read-only.")
 
     if readable:
@@ -198,7 +202,7 @@ def add_action(
     """
 
     @wraps(action.func)
-    def action_method(self, **kwargs):
+    def action_method(self: DirectThingClient, **kwargs: Any) -> Any:
         dependency_kwargs = {
             param.name: self._dependencies[param.name]
             for param in action.dependency_params

--- a/src/labthings_fastapi/decorators/__init__.py
+++ b/src/labthings_fastapi/decorators/__init__.py
@@ -37,7 +37,7 @@ not supported at this time.
 """
 
 from functools import wraps, partial
-from typing import Optional, Callable, overload
+from typing import Any, Optional, Callable, overload
 from ..descriptors import (
     ActionDescriptor,
     EndpointDescriptor,
@@ -45,7 +45,7 @@ from ..descriptors import (
 )
 
 
-def mark_thing_action(func: Callable, **kwargs) -> ActionDescriptor:
+def mark_thing_action(func: Callable, **kwargs: Any) -> ActionDescriptor:
     r"""Mark a method of a Thing as an Action.
 
     We replace the function with a descriptor that's a
@@ -65,12 +65,12 @@ def mark_thing_action(func: Callable, **kwargs) -> ActionDescriptor:
 
 
 @overload
-def thing_action(func: Callable, **kwargs) -> ActionDescriptor: ...
+def thing_action(func: Callable, **kwargs: Any) -> ActionDescriptor: ...
 
 
 @overload
 def thing_action(
-    **kwargs,
+    **kwargs: Any,
 ) -> Callable[
     [
         Callable,
@@ -81,7 +81,7 @@ def thing_action(
 
 @wraps(mark_thing_action)
 def thing_action(
-    func: Optional[Callable] = None, **kwargs
+    func: Optional[Callable] = None, **kwargs: Any
 ) -> (
     ActionDescriptor
     | Callable[
@@ -121,7 +121,7 @@ def thing_action(
 
 
 def fastapi_endpoint(
-    method: HTTPMethod, path: Optional[str] = None, **kwargs
+    method: HTTPMethod, path: Optional[str] = None, **kwargs: Any
 ) -> Callable[[Callable], EndpointDescriptor]:
     r"""Mark a function as a FastAPI endpoint without making it an action.
 

--- a/src/labthings_fastapi/dependencies/invocation.py
+++ b/src/labthings_fastapi/dependencies/invocation.py
@@ -146,7 +146,7 @@ class CancelEvent(threading.Event):
         threading.Event.__init__(self)
         self.invocation_id = id
 
-    def raise_if_set(self):
+    def raise_if_set(self) -> None:
         """Raise an exception if the event is set.
 
         This is intended as a compact alternative to:
@@ -161,7 +161,7 @@ class CancelEvent(threading.Event):
         if self.is_set():
             raise InvocationCancelledError("The action was cancelled.")
 
-    def sleep(self, timeout: float):
+    def sleep(self, timeout: float) -> None:
         r"""Sleep for a given time in seconds, but raise an exception if cancelled.
 
         This function can be used in place of `time.sleep`. It will usually behave

--- a/src/labthings_fastapi/example_things/__init__.py
+++ b/src/labthings_fastapi/example_things/__init__.py
@@ -74,7 +74,7 @@ class MyThing(Thing):
         return out
 
     @thing_action
-    def increment_counter(self):
+    def increment_counter(self) -> None:
         """Increment the counter property.
 
         This action doesn't do very much - all it does, in fact,
@@ -84,7 +84,7 @@ class MyThing(Thing):
         self.counter += 1
 
     @thing_action
-    def slowly_increase_counter(self, increments: int = 60, delay: float = 1):
+    def slowly_increase_counter(self, increments: int = 60, delay: float = 1) -> None:
         """Increment the counter slowly over a minute.
 
         :param increments: how many times to increment.
@@ -118,7 +118,7 @@ class ThingWithBrokenAffordances(Thing):
     """A Thing that raises exceptions in actions/properties."""
 
     @thing_action
-    def broken_action(self):
+    def broken_action(self) -> None:
         """Do something that raises an exception.
 
         :raise RuntimeError: every time.
@@ -126,7 +126,7 @@ class ThingWithBrokenAffordances(Thing):
         raise RuntimeError("This is a broken action")
 
     @lt_property
-    def broken_property(self):
+    def broken_property(self) -> None:
         """Raise an exception when the property is accessed.
 
         :raise RuntimeError: every time.
@@ -137,7 +137,7 @@ class ThingWithBrokenAffordances(Thing):
 class ThingThatCantInstantiate(Thing):
     """A Thing that raises an exception in __init__."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Fail to initialise.
 
         :raise RuntimeError: every time.
@@ -148,14 +148,14 @@ class ThingThatCantInstantiate(Thing):
 class ThingThatCantStart(Thing):
     """A Thing that raises an exception in __enter__."""
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         """Fail to start the thing.
 
         :raise RuntimeError: every time.
         """
         raise RuntimeError("This thing can't start")
 
-    def __exit__(self, exc_t: Any, exc_v: Any, exc_tb: Any):
+    def __exit__(self, exc_t: Any, exc_v: Any, exc_tb: Any) -> None:
         """Don't leave the thing as we never entered.
 
         :param exc_t: Exception type.

--- a/src/labthings_fastapi/outputs/blob.py
+++ b/src/labthings_fastapi/outputs/blob.py
@@ -46,6 +46,7 @@ import re
 import shutil
 from typing import (
     Annotated,
+    Any,
     AsyncGenerator,
     Callable,
     Literal,
@@ -215,7 +216,7 @@ class BlobFile:
     id: Optional[uuid.UUID] = None
     """A unique ID to identify the data in a `.BlobManager`."""
 
-    def __init__(self, file_path: str, media_type: str, **kwargs):
+    def __init__(self, file_path: str, media_type: str, **kwargs: Any):
         r"""Create a `.BlobFile` to wrap data stored on disk.
 
         `.BlobFile` objects wrap data stored on disk as files. They

--- a/src/labthings_fastapi/outputs/mjpeg_stream.py
+++ b/src/labthings_fastapi/outputs/mjpeg_stream.py
@@ -139,7 +139,7 @@ class MJPEGStream:
         self._ringbuffer: list[RingbufferEntry] = []
         self.reset(ringbuffer_size=ringbuffer_size)
 
-    def reset(self, ringbuffer_size: Optional[int] = None):
+    def reset(self, ringbuffer_size: Optional[int] = None) -> None:
         """Reset the stream and optionally change the ringbuffer size.
 
         Discard all frames from the ringbuffer and reset the frame index.
@@ -361,7 +361,7 @@ class MJPEGStreamDescriptor:
     This descriptor does not currently show up in the :ref:`wot_td`.
     """
 
-    def __init__(self, **kwargs: dict[str, Any]):
+    def __init__(self, **kwargs: Any):
         r"""Initialise an MJPEGStreamDescriptor.
 
         :param \**kwargs: keyword arguments are passed to the initialiser of
@@ -381,10 +381,10 @@ class MJPEGStreamDescriptor:
         self.name = name
 
     @overload
-    def __get__(self, obj: Literal[None], type=None) -> Self: ...  # noqa: D105
+    def __get__(self, obj: Literal[None], type: type | None = None) -> Self: ...  # noqa: D105
 
     @overload
-    def __get__(self, obj: Thing, type=None) -> MJPEGStream: ...  # noqa: D105
+    def __get__(self, obj: Thing, type: type | None = None) -> MJPEGStream: ...  # noqa: D105
 
     def __get__(
         self, obj: Optional[Thing], type: type[Thing] | None = None
@@ -452,5 +452,5 @@ class MJPEGStreamDescriptor:
             f"{thing.path}{self.name}/viewer",
             response_class=HTMLResponse,
         )
-        async def viewer_page():
+        async def viewer_page() -> HTMLResponse:
             return await self.viewer_page(f"{thing.path}{self.name}")

--- a/src/labthings_fastapi/properties.py
+++ b/src/labthings_fastapi/properties.py
@@ -381,7 +381,7 @@ class BaseProperty(BaseDescriptor[Value], Generic[Value]):
         # the function to the decorator.
         if not self.readonly:
 
-            def set_property(body):  # We'll annotate body later
+            def set_property(body: Any) -> None:  # We'll annotate body later
                 if isinstance(body, RootModel):
                     body = body.root
                 return self.__set__(thing, body)
@@ -402,7 +402,7 @@ class BaseProperty(BaseDescriptor[Value], Generic[Value]):
             summary=self.title,
             description=f"## {self.title}\n\n{self.description or ''}",
         )
-        def get_property():
+        def get_property() -> Any:
             return self.__get__(thing)
 
     def property_affordance(
@@ -443,6 +443,19 @@ class BaseProperty(BaseDescriptor[Value], Generic[Value]):
                 **data_schema.model_dump(exclude_none=True),
                 **pa.model_dump(exclude_none=True),
             }
+        )
+
+    def __set__(self, obj: Thing, value: Any) -> None:
+        """Set the property (stub method).
+
+        This is a stub ``__set__`` method to mark this as a data descriptor.
+
+        :param obj: The Thing on which we are setting the value.
+        :param value: The new value for the Thing.
+        :raises NotImplementedError: as this must be overridden by concrete classes.
+        """
+        raise NotImplementedError(
+            "__set__ must be overridden by property implementations."
         )
 
 
@@ -602,7 +615,7 @@ class DataProperty(BaseProperty[Value], Generic[Value]):
         if emit_changed_event:
             self.emit_changed_event(obj, value)
 
-    def _observers_set(self, obj: Thing):
+    def _observers_set(self, obj: Thing) -> WeakSet:
         """Return the observers of this property.
 
         Each observer in this set will be notified when the property is changed.
@@ -646,7 +659,7 @@ class DataProperty(BaseProperty[Value], Generic[Value]):
             value,
         )
 
-    async def emit_changed_event_async(self, obj: Thing, value: Value):
+    async def emit_changed_event_async(self, obj: Thing, value: Value) -> None:
         """Notify subscribers that the property has changed.
 
         This function may only be run in the `anyio` event loop. See
@@ -793,7 +806,7 @@ class FunctionalProperty(BaseProperty[Value], Generic[Value]):
         """
         return self.fget(obj)
 
-    def __set__(self, obj: Thing, value: Value):
+    def __set__(self, obj: Thing, value: Value) -> None:
         """Set the value of the property.
 
         :param obj: the `.Thing` on which the attribute is accessed.

--- a/src/labthings_fastapi/server/__init__.py
+++ b/src/labthings_fastapi/server/__init__.py
@@ -216,7 +216,7 @@ class ThingServer:
 
         self.blocking_portal = None
 
-    def add_things_view_to_app(self):
+    def add_things_view_to_app(self) -> None:
         """Add an endpoint that shows the list of attached things."""
         thing_server = self
 

--- a/src/labthings_fastapi/server/cli.py
+++ b/src/labthings_fastapi/server/cli.py
@@ -30,7 +30,7 @@ import uvicorn
 from . import ThingServer, server_from_config
 
 
-def get_default_parser():
+def get_default_parser() -> ArgumentParser:
     """Return the default CLI parser for LabThings.
 
     This can be used to add more arguments, for custom CLIs that make use of

--- a/src/labthings_fastapi/thing.py
+++ b/src/labthings_fastapi/thing.py
@@ -152,7 +152,7 @@ class Thing:
             return self.thing_description(base=str(request.base_url))
 
         @server.app.websocket(self.path + "ws")
-        async def websocket(ws: WebSocket):
+        async def websocket(ws: WebSocket) -> None:
             await websocket_endpoint(self, ws)
 
     # A private variable to hold the list of settings so it doesn't need to be
@@ -230,13 +230,14 @@ class Thing:
                 _LOGGER.warning("Error loading settings for %s", thing_name)
         self._setting_storage_path = setting_storage_path
 
-    def save_settings(self):
+    def save_settings(self) -> None:
         """Save settings to JSON.
 
         This is called whenever a setting is updated. All settings are written to
         the settings file every time.
         """
         if self._settings is not None:
+            assert self._setting_storage_path is not None
             setting_dict = {}
             for name in self._settings.keys():
                 value = getattr(self, name)
@@ -352,7 +353,7 @@ class Thing:
             raise KeyError(f"{property_name} is not a LabThings Property")
         prop._observers_set(self).add(stream)
 
-    def observe_action(self, action_name: str, stream: ObjectSendStream):
+    def observe_action(self, action_name: str, stream: ObjectSendStream) -> None:
         """Register a stream to receive action status change notifications.
 
         :param action_name: the action to register for.

--- a/src/labthings_fastapi/thing_description/__init__.py
+++ b/src/labthings_fastapi/thing_description/__init__.py
@@ -278,7 +278,7 @@ def jsonschema_to_dataschema(
     return output
 
 
-def type_to_dataschema(t: type, **kwargs) -> DataSchema:
+def type_to_dataschema(t: type, **kwargs: Any) -> DataSchema:
     r"""Convert a Python type to a Thing Description DataSchema.
 
     This makes use of pydantic's `schema_of` function to create a

--- a/src/labthings_fastapi/thing_description/_model.py
+++ b/src/labthings_fastapi/thing_description/_model.py
@@ -81,7 +81,7 @@ ThingContextType = Union[
 ]
 
 
-def uses_thing_context(v: ThingContextType):
+def uses_thing_context(v: ThingContextType) -> None:
     """Check the URLs in the ThingContextType are valid.
 
     This function makes ``assert`` statements, so will fail with an exception

--- a/src/labthings_fastapi/types/numpy.py
+++ b/src/labthings_fastapi/types/numpy.py
@@ -71,7 +71,7 @@ def np_to_listoflists(arr: np.ndarray) -> NestedListOfNumbers:
     :param arr: a `numpy.ndarray`.
     :return: a nested list of numbers.
     """
-    return arr.tolist()  # type: ignore[return-value]
+    return arr.tolist()
 
 
 def listoflists_to_np(lol: Union[NestedListOfNumbers, np.ndarray]) -> np.ndarray:

--- a/src/labthings_fastapi/utilities/introspection.py
+++ b/src/labthings_fastapi/utilities/introspection.py
@@ -114,9 +114,7 @@ def input_model_from_signature(
         p_type = Any if p.annotation is Parameter.empty else type_hints[name]
         # pydantic uses `...` to represent missing defaults (i.e. required params)
         default = Field(...) if p.default is Parameter.empty else p.default
-        # p_type below has a complicated type, but it is reasonable to
-        # call p_type a `type` and ignore the mypy error.
-        fields[name] = (p_type, default)  # type: ignore[assignment]
+        fields[name] = (p_type, default)
     model = create_model(  # type: ignore[call-overload]
         f"{func.__name__}_input",
         model_config=ConfigDict(extra="allow" if takes_v_kwargs else "forbid"),
@@ -176,7 +174,7 @@ def return_type(func: Callable) -> Type:
     """
     sig = inspect.signature(func)
     if sig.return_annotation == inspect.Signature.empty:
-        return Any  # type: ignore[return-value]
+        return Any
     else:
         # We use `get_type_hints` rather than just `sig.return_annotation`
         # because it resolves forward references, etc.

--- a/tests/test_locking_decorator.py
+++ b/tests/test_locking_decorator.py
@@ -1,0 +1,136 @@
+import time
+from typing import Callable, TypeVar, ParamSpec
+import functools
+from threading import RLock, Event, Thread
+
+from fastapi.testclient import TestClient
+import pytest
+
+import labthings_fastapi as lt
+from .temp_client import poll_task
+
+
+Value = TypeVar("Value")
+Params = ParamSpec("Params")
+
+
+def requires_lock(func: Callable[Params, Value]) -> Callable[Params, Value]:
+    """Decorate an action to require a lock."""
+
+    @functools.wraps(func)
+    def locked_func(*args, **kwargs):
+        lock: RLock = args[0]._lock
+        if not lock.acquire(blocking=False):
+            raise TimeoutError("Could not lock.")
+        try:
+            return func(*args, **kwargs)
+        finally:
+            lock.release()
+
+    return locked_func
+
+
+class LockedExample(lt.Thing):
+    """A Thing where only one action may happen at a time."""
+
+    flag: bool = lt.property(default=False)
+
+    def __init__(self):
+        """Initialise the lock."""
+        self._lock = RLock()  # This lock is used by @requires_lock
+        self._event = Event()  # This is used to keep tests quick
+        # by stopping waits as soon as they are no longer needed
+
+    @lt.thing_action
+    @requires_lock
+    def wait_wrapper(self, time: float = 1) -> None:
+        """Wait a specified time, calling wait_with_flag.
+
+        This lets us check the RLock correctly allows one locked
+        function to call another.
+        """
+        self.wait_with_flag(time)
+
+    @lt.thing_action
+    @requires_lock
+    def echo(self, message: str) -> str:
+        """Echo a message back to the sender."""
+        return message
+
+    @lt.thing_action
+    @requires_lock
+    def wait_with_flag(self, time: float = 1) -> None:
+        """Wait a specified time with the flag True."""
+        assert self.flag is False
+        self.flag = True
+        self._event.wait(time)
+        self.flag = False
+
+
+@pytest.fixture
+def thing(mocker) -> LockedExample:
+    """Instantiate the LockedExample thing."""
+    thing = LockedExample()
+    thing._labthings_blocking_portal = mocker.Mock()
+    return thing
+
+
+def test_echo(thing: LockedExample) -> None:
+    """Check the example function works.
+
+    Having this in a test function means if it raises an
+    exception, we can be sure it's because of the lock, and
+    not just a typo in the test.
+    """
+    assert thing.echo("test") == "test"
+
+
+def wait_for_flag(thing: LockedExample) -> None:
+    """Wait until the flag is set, so we know the lock is acquired."""
+    while not thing.flag:
+        time.sleep(0.001)
+
+
+def test_locking(thing: LockedExample) -> None:
+    """Check the lock prevents concurrent access."""
+    thread = Thread(target=thing.wait_wrapper)
+    thread.start()
+    wait_for_flag(thing)
+    with pytest.raises(TimeoutError):
+        # This should fail because the lock is acquired
+        test_echo(thing)
+    thing._event.set()  # tell the thread to stop
+    thread.join()
+    # Check the lock is now released - other actions should work
+    test_echo(thing)
+
+
+def echo_via_client(client):
+    """Use a POST request to run the echo action."""
+    r = client.post("/thing/echo", json={"message": "test"})
+    r.raise_for_status()
+    return poll_task(client, r.json())
+
+
+def test_locking_in_server():
+    """Check the lock works within LabThings."""
+    server = lt.ThingServer()
+    thing = LockedExample()
+    server.add_thing(thing, "/thing")
+    with TestClient(server.app) as client:
+        # Start a long task
+        r1 = client.post("/thing/wait_wrapper", json={})
+        # Wait for it to start
+        while client.get("/thing/flag").json() is not True:
+            time.sleep(0.01)
+        # Try another action and check it fails
+        inv2 = echo_via_client(client)
+        assert inv2["status"] == "error"
+        # Instruct the first task to stop
+        thing._event.set()  # stop the first action
+        inv1 = poll_task(client, r1.json())  # wait for it to complete
+        assert inv1["status"] == "completed"  # check there's no error
+        # This action should succeed now
+        inv3 = echo_via_client(client)
+        assert inv3["status"] == "completed"
+        assert inv3["output"] == "test"

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -220,6 +220,20 @@ def test_baseproperty_add_to_fastapi():
     assert set(entry.keys()) == set(["get", "put"])
 
 
+def test_baseproperty_set_error():
+    """Check `.Baseproperty.__set__` raises an error and is overridden."""
+    assert tp.DataProperty.__get__ is tp.BaseProperty.__get__
+    assert tp.DataProperty.__set__ is not tp.BaseProperty.__set__
+    assert tp.FunctionalProperty.__set__ is not tp.BaseProperty.__set__
+
+    class Example:
+        bp: int = tp.BaseProperty()
+
+    example = Example()
+    with pytest.raises(NotImplementedError):
+        example.bp = 0
+
+
 def test_decorator_exception():
     r"""Check decorators work as expected when the setter has a different name.
 

--- a/typing_tests/thing_definitions.py
+++ b/typing_tests/thing_definitions.py
@@ -59,7 +59,7 @@ assert_type(unbound_prop_2, int)
 
 
 @lt.property
-def strprop(self) -> str:
+def strprop(self: typing.Any) -> str:
     """A functional property that should not cause mypy errors."""
     return "foo"
 
@@ -213,7 +213,7 @@ class TestFunctionalProperty(lt.Thing):
         return 0
 
     @intprop2.setter
-    def set_intprop2(self, value: int):
+    def set_intprop2(self, value: int) -> None:
         """Setter for intprop2."""
         pass
 


### PR DESCRIPTION
In #101 and #156 it's clear there are situations where we'd like to be able to decorate actions. In #156 @julianstirling shared code that looked like it should work, but failed strangely.

This PR introduces test code for decorated actions. I was expecting it to fail, then I was going to explicitly support `__wrapped__` (which is how `functools.wraps` works) and watch it turn green wearing a smug expression. However, the test passes already: It turns out that reading the docs and using `inspect.signature` rather than accessing magic attributes directly has paid off, because wrapped functions are already supported. Apparently `functools.partial` objects should also work - this might be useful in a couple of places, but isn't relevant to this PR.

Unfortunately this means I can't reproduce #156, but I think these are useful tests for a use case that I didn't know we supported.

**This PR is based off the branch for #176 and should be merged afterwards**

It only touches two test files, if more changes are showing, that's because the previous PR is not in yet. It may need a rebase after #176 is in.