### PR TITLE
Use __config__ not model_config with create_model for pydatic 2.11 compatibility

### DIFF
--- a/src/labthings_fastapi/utilities/introspection.py
+++ b/src/labthings_fastapi/utilities/introspection.py
@@ -117,7 +117,7 @@ def input_model_from_signature(
         fields[name] = (p_type, default)
     model = create_model(  # type: ignore[call-overload]
         f"{func.__name__}_input",
-        model_config=ConfigDict(extra="allow" if takes_v_kwargs else "forbid"),
+        __config__=ConfigDict(extra="allow" if takes_v_kwargs else "forbid"),
         **fields,
     )
     # If there are no fields, we use a RootModel to allow none as well as {}


### PR DESCRIPTION
Pydantic 2.11 throws and error is `model_config` is used in `create_model`. [The docs](https://docs.pydantic.dev/latest/api/base_model/#pydantic.create_model) say to use `__config__`, this is tested to work with older pydantic too.