### PR TITLE
Thing connections to replace Thing dependencies

### DIFF
--- a/docs/source/concurrency.rst
+++ b/docs/source/concurrency.rst
@@ -11,7 +11,7 @@ In the case of properties, the HTTP response is only returned once the `.Thing` 
 
 Many of the functions that handle HTTP requests are asynchronous, running in an :mod:`anyio` event loop. This enables many HTTP connections to be handled at once with good efficiency. The `anyio documentation`_ describes the functions that link between async and threaded code. When the LabThings server is started, we create an :class:`anyio.from_thread.BlockingPortal`, which allows threaded code to run code asynchronously in the event loop.
 
-An action can obtain the blocking portal using the `~labthings_fastapi.dependencies.blocking_portal.BlockingPortal` dependency, i.e. by declaring an argument of that type. This avoids referring to the blocking portal through a global variable, which could lead to confusion if there are multiple event loops, e.g. during testing.
+An action can run async code using its server interface. See `.ThingServerInterface.start_async_task_soon` for details.
 
 There are relatively few occasions when `.Thing` code will need to consider this explicitly: more usually the blocking portal will be obtained by a LabThings function, for example the `.MJPEGStream` class.
 

--- a/docs/source/dependencies/dependencies.rst
+++ b/docs/source/dependencies/dependencies.rst
@@ -3,10 +3,18 @@
 Dependencies
 ============
 
+.. warning::
+
+    The use of dependencies is now deprecated. See `.thing_connection` and `.ThingServerInterface` for a more intuitive way to access that functionality.
+
 LabThings makes use of the powerful "dependency injection" mechanism in FastAPI. You can see the `FastAPI documentation`_ for more information. In brief, FastAPI dependencies are annotated types that instruct FastAPI to supply certain function arguments automatically. This removes the need to set up resources at the start of a function, and ensures everything the function needs is declared and typed clearly. The most common use for dependencies in LabThings is where an action needs to make use of another `.Thing` on the same `.ThingServer`.
 
 Inter-Thing dependencies
 ------------------------
+
+.. warning::
+
+    These dependencies are deprecated - see `.thing_connection` instead.
 
 Simple actions depend only on their input parameters and the `.Thing` on which they are defined. However, it's quite common to need something else, for example accessing another `.Thing` instance on the same LabThings server. There are two important principles to bear in mind here:
 

--- a/docs/source/dependencies/example.py
+++ b/docs/source/dependencies/example.py
@@ -5,7 +5,7 @@ from fastapi import Depends
 import labthings_fastapi as lt
 from labthings_fastapi.example_things import MyThing
 
-MyThingClient = lt.deps.direct_thing_client_class(MyThing, "/mything/")
+MyThingClient = lt.deps.direct_thing_client_class(MyThing, "mything")
 MyThingDep = Annotated[MyThingClient, Depends()]
 
 
@@ -19,8 +19,8 @@ class TestThing(lt.Thing):
 
 
 server = lt.ThingServer()
-server.add_thing(MyThing(), "/mything/")
-server.add_thing(TestThing(), "/testthing/")
+server.add_thing("mything", MyThing)
+server.add_thing("testthing", TestThing)
 
 if __name__ == "__main__":
     import uvicorn

--- a/docs/source/quickstart/counter.py
+++ b/docs/source/quickstart/counter.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
     server = lt.ThingServer()
 
     # The line below creates a TestThing instance and adds it to the server
-    server.add_thing(TestThing(), "/counter/")
+    server.add_thing("counter", TestThing)
 
     # We run the server using `uvicorn`:
     uvicorn.run(server.app, port=5000)

--- a/docs/source/tutorial/writing_a_thing.rst
+++ b/docs/source/tutorial/writing_a_thing.rst
@@ -30,9 +30,8 @@ Our first Thing will pretend to be a light: we can set its brightness and turn i
             self.is_on = not self.is_on
 
     
-    light = Light()
     server = lt.ThingServer()
-    server.add_thing("/light", light)
+    server.add_thing("light", Light)
 
     if __name__ == "__main__":
         import uvicorn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ addopts = [
     "--cov-report=html:htmlcov",
     "--cov-report=lcov",
 ]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
 
 [tool.ruff]
 target-version = "py310"

--- a/src/labthings_fastapi/__init__.py
+++ b/src/labthings_fastapi/__init__.py
@@ -20,6 +20,7 @@ code does not break if modules are rearranged.
 """
 
 from .thing import Thing
+from .thing_connections import thing_connection
 from .thing_server_interface import ThingServerInterface
 from .properties import property, setting, DataProperty, DataSetting
 from .decorators import (
@@ -46,6 +47,7 @@ __all__ = [
     "DataProperty",
     "DataSetting",
     "thing_action",
+    "thing_connection",
     "fastapi_endpoint",
     "deps",
     "outputs",

--- a/src/labthings_fastapi/__init__.py
+++ b/src/labthings_fastapi/__init__.py
@@ -20,6 +20,7 @@ code does not break if modules are rearranged.
 """
 
 from .thing import Thing
+from .thing_server_interface import ThingServerInterface
 from .properties import property, setting, DataProperty, DataSetting
 from .decorators import (
     thing_action,
@@ -30,7 +31,6 @@ from . import outputs
 from .outputs import blob
 from .server import ThingServer, cli
 from .client import ThingClient
-from .utilities import get_blocking_portal
 
 # The symbols in __all__ are part of our public API.
 # They are imported when using `import labthings_fastapi as lt`.
@@ -40,6 +40,7 @@ from .utilities import get_blocking_portal
 # re-export style, we may switch in the future.
 __all__ = [
     "Thing",
+    "ThingServerInterface",
     "property",
     "setting",
     "DataProperty",
@@ -52,5 +53,4 @@ __all__ = [
     "ThingServer",
     "cli",
     "ThingClient",
-    "get_blocking_portal",
 ]

--- a/src/labthings_fastapi/actions/__init__.py
+++ b/src/labthings_fastapi/actions/__init__.py
@@ -270,13 +270,13 @@ class Invocation(Thread):
         # self.action evaluates to an ActionDescriptor. This confuses mypy,
         # which thinks we are calling ActionDescriptor.__get__.
         action: ActionDescriptor = self.action  # type: ignore[call-overload]
+        # Create a logger just for this invocation, keyed to the invocation id
+        # Logs that go to this logger will be copied into `self._log`
+        handler = DequeLogHandler(dest=self._log)
+        logger = invocation_logger(self.id)
+        logger.addHandler(handler)
         try:
             action.emit_changed_event(self.thing, self._status.value)
-
-            # Capture just this thread's log messages
-            handler = DequeLogHandler(dest=self._log)
-            logger = invocation_logger(self.id)
-            logger.addHandler(handler)
 
             thing = self.thing
             kwargs = model_to_dict(self.input)

--- a/src/labthings_fastapi/dependencies/metadata.py
+++ b/src/labthings_fastapi/dependencies/metadata.py
@@ -17,6 +17,12 @@ from .thing_server import find_thing_server
 def thing_states_getter(request: Request) -> Callable[[], Mapping[str, Any]]:
     """Generate a function to retrieve metadata from all Things in this server.
 
+    .. warning::
+
+        This function is deprecated in favour of the `.ThingServerInterface`, which
+        is available as a property of every Thing.
+        See `.ThingServerInterface.get_thing_states` for more information.
+
     This is intended to make it easy for a `.Thing` to summarise the other
     `.Things` in the same server, as is often appropriate when embedding metadata
     in data files. For example, it's used to populate the ``UserComment``
@@ -64,7 +70,11 @@ def thing_states_getter(request: Request) -> Callable[[], Mapping[str, Any]]:
 GetThingStates = Annotated[
     Callable[[], Mapping[str, Any]], Depends(thing_states_getter)
 ]
-"""A ready-made FastAPI dependency, returning a function to collect metadata.
+r"""A ready-made FastAPI dependency, returning a function to collect metadata.
+
+.. warning::
+
+    This dependency is deprecated in favour of the `.ThingServerInterface`\ .
 
 This calls `.thing_states_getter` to provide a function that supplies a
 dictionary of metadata. It describes the state of all `.Thing` instances on

--- a/src/labthings_fastapi/descriptors/action.py
+++ b/src/labthings_fastapi/descriptors/action.py
@@ -33,7 +33,7 @@ from ..utilities.introspection import (
 from ..outputs.blob import BlobIOContextDep
 from ..thing_description import type_to_dataschema
 from ..thing_description._model import ActionAffordance, ActionOp, Form
-from ..utilities import labthings_data, get_blocking_portal
+from ..utilities import labthings_data
 from ..exceptions import NotConnectedToServerError
 
 if TYPE_CHECKING:
@@ -200,19 +200,8 @@ class ActionDescriptor:
 
         :param obj: The `.Thing` on which the action is being observed.
         :param status: The status of the action, to be sent to observers.
-
-        :raise NotConnectedToServerError: if the Thing calling the action is not
-            connected to a server with a running event loop.
         """
-        runner = get_blocking_portal(obj)
-        if not runner:
-            thing_name = obj.__class__.__name__
-            msg = (
-                f"Cannot emit action changed event. Is {thing_name} connected to "
-                "a running server?"
-            )
-            raise NotConnectedToServerError(msg)
-        runner.start_task_soon(
+        obj._thing_server_interface.start_async_task_soon(
             self.emit_changed_event_async,
             obj,
             status,

--- a/src/labthings_fastapi/example_things/__init__.py
+++ b/src/labthings_fastapi/example_things/__init__.py
@@ -137,11 +137,12 @@ class ThingWithBrokenAffordances(Thing):
 class ThingThatCantInstantiate(Thing):
     """A Thing that raises an exception in __init__."""
 
-    def __init__(self) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         """Fail to initialise.
 
         :raise RuntimeError: every time.
         """
+        super().__init__(**kwargs)
         raise RuntimeError("This thing can't be instantiated")
 
 

--- a/src/labthings_fastapi/example_things/__init__.py
+++ b/src/labthings_fastapi/example_things/__init__.py
@@ -138,7 +138,9 @@ class ThingThatCantInstantiate(Thing):
     """A Thing that raises an exception in __init__."""
 
     def __init__(self, **kwargs: Any) -> None:
-        """Fail to initialise.
+        r"""Fail to initialise.
+
+        :param \**kwargs: keyword arguments passed to Thing.__init__
 
         :raise RuntimeError: every time.
         """

--- a/src/labthings_fastapi/exceptions.py
+++ b/src/labthings_fastapi/exceptions.py
@@ -82,3 +82,12 @@ class ThingNotConnectedError(RuntimeError):
     should be mocked), or because it has been accessed before ``__enter__``
     has been called.
     """
+
+
+class ThingConnectionError(RuntimeError):
+    """A ThingConnection could not be set up.
+
+    This error is raised if the LabThings server is unable to set up a
+    ThingConnection, for example because the named Thing does not exist,
+    or is of the wrong type, or is not specified and there is no default.
+    """

--- a/src/labthings_fastapi/exceptions.py
+++ b/src/labthings_fastapi/exceptions.py
@@ -51,3 +51,34 @@ class PropertyNotObservableError(RuntimeError):
     observable: functional properties (using a getter/setter) may not be
     observed.
     """
+
+
+class InconsistentTypeError(TypeError):
+    """Different type hints have been given for a descriptor.
+
+    Some descriptors in LabThings, particularly `.DataProperty` and `.ThingConnection`
+    may have their type specified in different ways. If multiple type hints are
+    provided, they must match. See `.property` for more details.
+    """
+
+
+class MissingTypeError(TypeError):
+    """No type hints have been given for a descriptor that requires a type.
+
+    Every property and thing connection should have a type hint,
+    There are different ways of providing these type hints.
+    This error indicates that no type hint was found.
+
+    See documentation for `.property` and `.thing_connection` for more details.
+    """
+
+
+class ThingNotConnectedError(RuntimeError):
+    """ThingConnections have not yet been set up.
+
+    This error is raised if a ThingConnection is accessed before the `.Thing` has
+    been supplied by the LabThings server. This usually happens because either
+    the `.Thing` is being used without a server (in which case the attribute
+    should be mocked), or because it has been accessed before ``__enter__``
+    has been called.
+    """

--- a/src/labthings_fastapi/outputs/mjpeg_stream.py
+++ b/src/labthings_fastapi/outputs/mjpeg_stream.py
@@ -452,7 +452,7 @@ class MJPEGStreamDescriptor:
 
 
             server = lt.ThingServer()
-            server.add_thing(Camera(), "/camera")
+            server.add_thing("camera", Camera)
 
         :param app: the `fastapi.FastAPI` application to which we are being added.
         :param thing: the host `.Thing` instance.

--- a/src/labthings_fastapi/outputs/mjpeg_stream.py
+++ b/src/labthings_fastapi/outputs/mjpeg_stream.py
@@ -321,10 +321,6 @@ class MJPEGStream:
         are handled.
 
         :param frame: The frame to add
-        :param portal: The blocking portal to use for scheduling tasks.
-            This is necessary because tasks are handled asynchronously.
-            The blocking portal may be obtained with a dependency, in
-            `labthings_fastapi.dependencies.blocking_portal.BlockingPortal`.
 
         :raise ValueError: if the supplied frame does not start with the JPEG
             start bytes and end with the end bytes.

--- a/src/labthings_fastapi/outputs/mjpeg_stream.py
+++ b/src/labthings_fastapi/outputs/mjpeg_stream.py
@@ -24,7 +24,6 @@ from copy import copy
 from contextlib import asynccontextmanager
 import threading
 import anyio
-from anyio.from_thread import BlockingPortal
 import logging
 
 if TYPE_CHECKING:

--- a/src/labthings_fastapi/properties.py
+++ b/src/labthings_fastapi/properties.py
@@ -653,19 +653,8 @@ class DataProperty(BaseProperty[Value], Generic[Value]):
 
         :param obj: the `.Thing` to which we are attached.
         :param value: the new property value, to be sent to observers.
-
-        :raise NotConnectedToServerError: if the Thing that is calling the property
-            update is not connected to a server with a running event loop.
         """
-        runner = obj._labthings_blocking_portal
-        if not runner:
-            thing_name = obj.__class__.__name__
-            msg = (
-                f"Cannot emit property updated changed event. Is {thing_name} "
-                "connected to a running server?"
-            )
-            raise NotConnectedToServerError(msg)
-        runner.start_task_soon(
+        obj._thing_server_interface.start_async_task_soon(
             self.emit_changed_event_async,
             obj,
             value,
@@ -751,7 +740,8 @@ class FunctionalProperty(BaseProperty[Value], Generic[Value]):
         .. code-block:: python
 
             class MyThing(lt.Thing):
-                def __init__(self):
+                def __init__(self, thing_server_interface):
+                    super().__init__(thing_server_interface=thing_server_interface)
                     self._myprop: int = 0
 
                 @lt.property

--- a/src/labthings_fastapi/properties.py
+++ b/src/labthings_fastapi/properties.py
@@ -72,7 +72,7 @@ from .thing_description._model import (
 )
 from .utilities import labthings_data, wrap_plain_types_in_rootmodel
 from .utilities.introspection import return_type
-from .base_descriptor import BaseDescriptor, FieldTypedBaseDescriptor
+from .base_descriptor import FieldTypedBaseDescriptor
 from .exceptions import (
     NotConnectedToServerError,
     ReadOnlyPropertyError,
@@ -302,7 +302,7 @@ def property(
     )
 
 
-class BaseProperty(BaseDescriptor[Value], Generic[Value]):
+class BaseProperty(FieldTypedBaseDescriptor[Value], Generic[Value]):
     """A descriptor that marks Properties on Things.
 
     This class is used to determine whether an attribute of a `.Thing` should
@@ -318,15 +318,6 @@ class BaseProperty(BaseDescriptor[Value], Generic[Value]):
         super().__init__()
         self._model: type[BaseModel] | None = None
         self.readonly: bool = False
-
-    @builtins.property
-    def value_type(self) -> type[Value]:
-        """The type of this descriptor's value.
-
-        :raises NotImplementedError: because this method must be overridden.
-        :return: the type of the descriptor's value.
-        """
-        raise NotImplementedError
 
     @builtins.property
     def model(self) -> type[BaseModel]:
@@ -451,9 +442,7 @@ class BaseProperty(BaseDescriptor[Value], Generic[Value]):
         )
 
 
-class DataProperty(
-    FieldTypedBaseDescriptor[Value], BaseProperty[Value], Generic[Value]
-):
+class DataProperty(BaseProperty[Value], Generic[Value]):
     """A Property descriptor that acts like a regular variable.
 
     `.DataProperty` descriptors remember their value, and can be read and
@@ -512,12 +501,6 @@ class DataProperty(
             default=default, default_factory=default_factory
         )
         self.readonly = readonly
-
-    @builtins.property
-    def value_type(self) -> type[Value]:  # noqa: DOC201
-        """The type of the descriptor's value."""
-        self.assert_set_name_called()
-        return super().value_type
 
     def instance_get(self, obj: Thing) -> Value:
         """Return the property's value.

--- a/src/labthings_fastapi/properties.py
+++ b/src/labthings_fastapi/properties.py
@@ -617,14 +617,6 @@ class FunctionalProperty(BaseProperty[Value], Generic[Value]):
         self.readonly: bool = True
 
     @builtins.property
-    def value_type(self) -> type[Value]:
-        """The type of this descriptor's value.
-
-        :return: the type of the descriptor's value.
-        """
-        return self._type
-
-    @builtins.property
     def fget(self) -> ValueGetter:  # noqa: DOC201
         """The getter function."""
         return self._fget

--- a/src/labthings_fastapi/properties.py
+++ b/src/labthings_fastapi/properties.py
@@ -85,14 +85,15 @@ if TYPE_CHECKING:
 
 # Note on ignored linter codes:
 #
-# D103 refers to missing docstrings. I have ignored this on @overload definitions
-# because they shouldn't have docstrings - the docstring belongs only on the
-# function they overload.
-# D105 is the same as D103, but for __init__ (i.e. magic methods).
-# DOC101 and DOC103 are also a result of overloads not having docstrings
-# DOC201 is ignored on properties. Because we are overriding the
-# builtin `property`, we are using `@builtins.property` which is not recognised
-# by pydoclint as a property. I've therefore ignored those codes manually.
+# DOC101 and DOC103 are a result of overloads not having docstrings. While
+#     the related D codes (checked by Ruff) don't flag overloads, pydoclint
+#     doesn't ignore overloads. This is most likely a pydoclint bug that
+#     we are working around.
+# DOC201 is ignored on properties.
+#     Because we are overriding the
+#     builtin `property`, we are using `@builtins.property` which is not
+#     recognised by pydoclint as a property. I've therefore ignored those
+#     codes manually.
 # pydocstyle ("D" codes) is run in Ruff and correctly recognises
 # builtins.property as a property decorator.
 
@@ -207,19 +208,17 @@ def default_factory_from_arguments(
 
 # See comment at the top of the file regarding ignored linter rules.
 @overload  # use as a decorator  @property
-def property(  # noqa: D103
+def property(
     getter: Callable[[Any], Value],
 ) -> FunctionalProperty[Value]: ...
 
 
 @overload  # use as `field: int = property(default=0)`
-def property(  # noqa: D103
-    *, default: Value, readonly: bool = False
-) -> Value: ...
+def property(*, default: Value, readonly: bool = False) -> Value: ...
 
 
 @overload  # use as `field: int = property(default_factory=lambda: 0)`
-def property(  # noqa: D103
+def property(
     *, default_factory: Callable[[], Value], readonly: bool = False
 ) -> Value: ...
 
@@ -480,12 +479,12 @@ class DataProperty(BaseProperty[Value], Generic[Value]):
     """
 
     @overload
-    def __init__(  # noqa: D105,D107,DOC101,DOC103
+    def __init__(  # noqa: DOC101,DOC103
         self, default: Value, *, readonly: bool = False
     ) -> None: ...
 
     @overload
-    def __init__(  # noqa: D105,D107,DOC101,DOC103
+    def __init__(  # noqa: DOC101,DOC103
         self, *, default_factory: ValueFactory, readonly: bool = False
     ) -> None: ...
 
@@ -833,19 +832,17 @@ class FunctionalProperty(BaseProperty[Value], Generic[Value]):
 
 
 @overload  # use as a decorator  @setting
-def setting(  # noqa: D103
+def setting(
     getter: Callable[[Any], Value],
 ) -> FunctionalSetting[Value]: ...
 
 
 @overload  # use as `field: int = setting(default=0)``
-def setting(  # noqa: D103
-    *, default: Value, readonly: bool = False
-) -> Value: ...
+def setting(*, default: Value, readonly: bool = False) -> Value: ...
 
 
 @overload  # use as `field: int = setting(default_factory=lambda: 0)`
-def setting(  # noqa: D103
+def setting(
     *, default_factory: Callable[[], Value], readonly: bool = False
 ) -> Value: ...
 

--- a/src/labthings_fastapi/properties.py
+++ b/src/labthings_fastapi/properties.py
@@ -601,6 +601,8 @@ class FunctionalProperty(BaseProperty[Value], Generic[Value]):
         tools understand that it functions like a property.
 
         :param fget: the getter function, called when the property is read.
+
+        :raises MissingTypeError: if the getter does not have a return type annotation.
         """
         super().__init__()
         self._fget: ValueGetter = fget

--- a/src/labthings_fastapi/server/__init__.py
+++ b/src/labthings_fastapi/server/__init__.py
@@ -153,17 +153,27 @@ class ThingServer:
         args: Sequence[Any] | None = None,
         kwargs: Mapping[str, Any] | None = None,
     ) -> ThingSubclass:
-        """Add a thing to the server.
+        r"""Add a thing to the server.
+
+        This function will create an instance of ``thing_subclass`` and supply
+        the ``args`` and ``kwargs`` arguments to its ``__init__`` method. That
+        instance will then be added to the server with the given name.
 
         :param name: The name to use for the thing. This will be part of the URL
             used to access the thing, and must only contain alphanumeric characters,
             hyphens and underscores.
         :param thing_subclass: The `.Thing` subclass to add to the server.
+        :param args: positional arguments to pass to the constructor of
+            ``thing_subclass``\ .
         :param kwargs: keyword arguments to pass to the constructor of
-            ``thing_subclass``.
+            ``thing_subclass``\ .
+
+        :returns: the instance of ``thing_subclass`` that was created and added
+            to the server. There is no need to retain a reference to this, as it
+            is stored in the server's dictionary of `.Thing` instances.
 
         :raise ValueError: if ``path`` contains invalid characters.
-        :raise KeyError: if a `.Thing` has already been added at ``path``.
+        :raise KeyError: if a `.Thing` has already been added at ``path``\ .
         :raise TypeError: if ``thing_subclass`` is not a subclass of `.Thing`
             or if ``name`` is not string-like. This usually means arguments
             are being passed the wrong way round.

--- a/src/labthings_fastapi/server/__init__.py
+++ b/src/labthings_fastapi/server/__init__.py
@@ -234,6 +234,16 @@ class ThingServer:
         """Connect the `thing_connection` attributes of Things.
 
         A `.Thing` may have attributes defined as ``lt.thing_connection()``, which
+        will be populated after all `.Thing` instances are loaded on the server.
+
+        This function is responsible for supplying the `.Thing` instances required
+        for each connection. This will be done by using the name specified either
+        in the connection's default, or in the configuration of the server.
+
+        :raises ThingConnectionError: if a `.Thing` named in either the default
+            or the server configuration is missing or of the wrong type. If no
+            `.Thing` is specified (i.e. there is no default and it is not configured),
+            an error will also be raised.
         """
         for thing_name, thing in self.things.items():
             config = self.thing_connections.get(thing_name, {})

--- a/src/labthings_fastapi/server/__init__.py
+++ b/src/labthings_fastapi/server/__init__.py
@@ -247,10 +247,6 @@ class ThingServer:
         :param app: The FastAPI application wrapped by the server.
         :yield: no value. The FastAPI application will serve requests while this
             function yields.
-
-        :raises RuntimeError: if a `.Thing` already has a blocking portal attached.
-            This should never happen, and suggests the server is being used to
-            serve a `.Thing` that is already being served elsewhere.
         """
         async with BlockingPortal() as portal:
             # We create a blocking portal to allow threaded code to call async code
@@ -325,7 +321,6 @@ def server_from_config(config: dict) -> ThingServer:
 
     :raise ImportError: if a Thing could not be loaded from the specified
         object reference.
-    :raise TypeError: if a class is specified that does not subclass `.Thing`\ .
     """
     server = ThingServer(config.get("settings_folder", None))
     for name, thing in config.get("things", {}).items():

--- a/src/labthings_fastapi/server/__init__.py
+++ b/src/labthings_fastapi/server/__init__.py
@@ -35,6 +35,9 @@ from ..outputs.blob import BlobDataManager
 PATH_REGEX = re.compile(r"^([a-zA-Z0-9\-_]+)$")
 
 
+ThingSubclass = TypeVar("ThingSubclass", bound=Thing)
+
+
 class ThingServer:
     """Use FastAPI to serve `.Thing` instances.
 
@@ -146,10 +149,10 @@ class ThingServer:
     def add_thing(
         self,
         name: str,
-        thing_subclass: type[Thing],
+        thing_subclass: type[ThingSubclass],
         args: Sequence[Any] | None = None,
         kwargs: Mapping[str, Any] | None = None,
-    ) -> None:
+    ) -> ThingSubclass:
         """Add a thing to the server.
 
         :param name: The name to use for the thing. This will be part of the URL
@@ -191,6 +194,7 @@ class ThingServer:
             path=self.path_for_thing(name),
             setting_storage_path=os.path.join(settings_folder, "settings.json"),
         )
+        return thing
 
     def path_for_thing(self, name: str) -> str:
         """Return the path for a thing with the given name.

--- a/src/labthings_fastapi/server/__init__.py
+++ b/src/labthings_fastapi/server/__init__.py
@@ -252,7 +252,9 @@ class ThingServer:
                     continue
                 target = config.get(attr_name, attr.default)
                 try:
-                    if isinstance(target, str | None):
+                    if target is None:
+                        attr.connect(thing, None)
+                    elif isinstance(target, str):
                         attr.connect(thing, self.things[target])
                     elif isinstance(target, Sequence):
                         attr.connect(thing, [self.things[t] for t in target])

--- a/src/labthings_fastapi/server/__init__.py
+++ b/src/labthings_fastapi/server/__init__.py
@@ -32,7 +32,7 @@ from ..outputs.blob import BlobDataManager
 # A path should be made up of names separated by / as a path separator.
 # Each name should be made of alphanumeric characters, hyphen, or underscore.
 # This regex enforces a trailing /
-PATH_REGEX = re.compile(r"^/([a-zA-Z0-9\-_]+\/)+$")
+PATH_REGEX = re.compile(r"^([a-zA-Z0-9\-_]+)$")
 
 
 class ThingServer:
@@ -161,8 +161,12 @@ class ThingServer:
 
         :raise ValueError: if ``path`` contains invalid characters.
         :raise KeyError: if a `.Thing` has already been added at ``path``.
-        :raise TypeError: if ``thing_subclass`` is not a subclass of `.Thing`.
+        :raise TypeError: if ``thing_subclass`` is not a subclass of `.Thing`
+            or if ``name`` is not string-like. This usually means arguments
+            are being passed the wrong way round.
         """
+        if not isinstance(name, str):
+            raise TypeError("Thing names must be strings.")
         if PATH_REGEX.match(name) is None:
             msg = (
                 f"'{name}' contains unsafe characters. Use only alphanumeric "

--- a/src/labthings_fastapi/server/__init__.py
+++ b/src/labthings_fastapi/server/__init__.py
@@ -197,7 +197,14 @@ class ThingServer:
             kwargs = {}
         interface = ThingServerInterface(name=name, server=self)
         # This is where we instantiate the Thing
-        thing = thing_subclass(*args, **kwargs, thing_server_interface=interface)
+        # I've had to ignore this line because the *args causes an error.
+        # Given that *args and **kwargs are very loosely typed anyway, this
+        # doesn't lose us much.
+        thing = thing_subclass(
+            *args,
+            **kwargs,
+            thing_server_interface=interface,
+        )  # type: ignore[misc]
         self._things[name] = thing
         settings_folder = os.path.join(self.settings_folder, name)
         os.makedirs(settings_folder, exist_ok=True)

--- a/src/labthings_fastapi/server/__init__.py
+++ b/src/labthings_fastapi/server/__init__.py
@@ -196,6 +196,7 @@ class ThingServer:
         if kwargs is None:
             kwargs = {}
         interface = ThingServerInterface(name=name, server=self)
+        os.makedirs(interface.settings_folder, exist_ok=True)
         # This is where we instantiate the Thing
         # I've had to ignore this line because the *args causes an error.
         # Given that *args and **kwargs are very loosely typed anyway, this
@@ -206,12 +207,8 @@ class ThingServer:
             thing_server_interface=interface,
         )  # type: ignore[misc]
         self._things[name] = thing
-        settings_folder = os.path.join(self.settings_folder, name)
-        os.makedirs(settings_folder, exist_ok=True)
         thing.attach_to_server(
             server=self,
-            path=self.path_for_thing(name),
-            setting_storage_path=os.path.join(settings_folder, "settings.json"),
         )
         return thing
 

--- a/src/labthings_fastapi/thing.py
+++ b/src/labthings_fastapi/thing.py
@@ -101,6 +101,11 @@ class Thing:
         """The path at which the `.Thing` is exposed over HTTP."""
         return self._thing_server_interface.path
 
+    @property
+    def name(self) -> str:
+        """The name of this Thing, as known to the server."""
+        return self._thing_server_interface.name
+
     async def __aenter__(self) -> Self:
         """Context management is used to set up/close the thing.
 

--- a/src/labthings_fastapi/thing.py
+++ b/src/labthings_fastapi/thing.py
@@ -83,7 +83,16 @@ class Thing:
         """Initialise a Thing.
 
         The most important function of ``__init__`` is attaching the
-        thing_server_interface, and setting the path.
+        thing_server_interface, and setting the path. Note that `.Thing`
+        instances are usually created by a `.ThingServer` and not instantiated
+        directly: if you do make a `.Thing` directly, you will need to supply
+        a `.ThingServerInterface` that is connected to a `.ThingServer` or a
+        suitable mock object.
+
+        :param thing_server_interface: The interface to the server that
+            is hosting this Thing. It will be supplied when the `.Thing` is
+            instantiated by the `.ThingServer` or by
+            `.create_thing_without_server` which generates a mock interface.
         """
         self._thing_server_interface = thing_server_interface
 

--- a/src/labthings_fastapi/thing_connection.py
+++ b/src/labthings_fastapi/thing_connection.py
@@ -1,0 +1,107 @@
+r"""Facilitate connections between Things.
+
+It is often desirable for two Things in the same server to be able to communicate.
+In order to do this in a nicely typed way that is easy to test and inspect,
+LabThings-FastAPI provides the `.thing_connection`\ . This allows a `.Thing`
+to declare that it depends on another `.Thing` being present, and provides a way for
+the server to automatically connect the two when the server is set up.
+
+Thing connections are set up **after** all the `.Thing` instances are initialised.
+This means you should not rely on them during initialisation: if you attempt to
+access a connection before it is provided, it will raise an exception. The
+advantage of making connections after initialisation is that circular connections
+are not a problem: Thing `a` may depend on Thing `b` and vice versa.
+
+As with properties, thing connections will usually be declared using the function
+`.thing_connection` rather than the descriptor directly. This allows them to be
+typed and documented on the class, i.e.
+
+.. code-block:: python
+
+    import labthings_fastapi as lt
+
+
+    class ThingA(lt.Thing):
+        "A class that doesn't do much."
+
+        @lt.action
+        def say_hello(self) -> str:
+            "A canonical example function."
+            return "Hello world."
+
+
+    class ThingB(lt.Thing):
+        "A class that relies on ThingA."
+
+        thing_a: ThingA = lt.thing_connection()
+
+        @lt.action
+        def say_hello(self) -> str:
+            "I'm too lazy to say hello, ThingA does it for me."
+            return self.thing_a.say_hello()
+"""
+
+from typing import Generic, TypeVar, TYPE_CHECKING
+from weakref import WeakKeyDictionary, ref
+from .base_descriptor import FieldTypedBaseDescriptor
+from .exceptions import ThingNotConnectedError
+
+if TYPE_CHECKING:
+    from .thing import Thing
+
+
+ThingSubclass = TypeVar("ThingSubclass", bound=Thing)
+
+
+class ThingConnection(Generic[ThingSubclass], FieldTypedBaseDescriptor[ThingSubclass]):
+    """A descriptor that returns an instance of a Thing from this server.
+
+    Thing connections allow `.Thing` instances to access other `.Thing` instances
+    in the same LabThings server.
+    """
+
+    def __init__(self, *, default_path: str | None = None) -> None:
+        """Declare a ThingConnection.
+
+        :param default_name: The name of the Thing that will be connected by default.
+        """
+        self._default_path = default_path
+        self._things: WeakKeyDictionary[Thing, ref[ThingSubclass]] = WeakKeyDictionary()
+
+    def connect_thing(self, host_thing: Thing, connected_thing: ThingSubclass) -> None:
+        r"""Connect a `.Thing` to a `.ThingConnection`\ .
+
+        This method sets up a ThingConnection on ``host_thing`` such that it will
+        supply ``connected_thing`` when accessed.
+        """
+        if not isinstance(connected_thing, self.value_type):
+            msg = (
+                f"Can't connect {connected_thing} to {host_thing}.{self.name}. "
+                f"This ThingConnection must be of type {self.value_type}."
+            )
+            raise TypeError(msg)
+        self._things[host_thing] = ref(connected_thing)
+
+    def instance_get(self, obj: Thing) -> ThingSubclass:
+        r"""Supply the connected `.Thing`\ .
+
+        :raises ThingNotConnectedError: if the ThingConnection has not yet been set up.
+        """
+        try:
+            thing_ref = self._things[obj]
+            return thing_ref()
+        except KeyError as e:
+            msg = f"{self.name} has not been connected to a Thing yet."
+            raise ThingNotConnectedError(msg) from e
+        # Note that ReferenceError is deliberately not handled: the Thing
+        # referred to by thing_ref should exist until the server has shut down.
+
+    def __set__(self, obj: Thing, value: ThingSubclass) -> None:
+        """Raise an error as this is a read-only descriptor.
+
+        :param obj: the `.Thing` on which the descriptor is defined.
+        :param value: the value being assigned.
+
+        :raises AttributeError: this descriptor is not writeable.
+        """
+        raise AttributeError("This descriptor is read-only.")

--- a/src/labthings_fastapi/thing_connections.py
+++ b/src/labthings_fastapi/thing_connections.py
@@ -63,7 +63,7 @@ class ThingConnection(Generic[ThingSubclass], FieldTypedBaseDescriptor[ThingSubc
     def __init__(self, *, default: str | None = None) -> None:
         """Declare a ThingConnection.
 
-        :param default_name: The name of the Thing that will be connected by default.
+        :param default: The name of the Thing that will be connected by default.
         """
         super().__init__()
         self._default = default
@@ -83,6 +83,13 @@ class ThingConnection(Generic[ThingSubclass], FieldTypedBaseDescriptor[ThingSubc
 
         This method sets up a ThingConnection on ``host_thing`` such that it will
         supply ``connected_thing`` when accessed.
+
+        :param host_thing: the `.Thing` on which the connection is defined.
+        :param connected_thing: the `.Thing` that will be available as the value
+            of the `.ThingConnection`\ .
+
+        :raises ThingConnectionError: if the supplied `.Thing` is of the wrong
+            type.
         """
         if not isinstance(connected_thing, self.value_type):
             msg = (
@@ -94,6 +101,10 @@ class ThingConnection(Generic[ThingSubclass], FieldTypedBaseDescriptor[ThingSubc
 
     def instance_get(self, obj: "Thing") -> ThingSubclass:
         r"""Supply the connected `.Thing`\ .
+
+        :param obj: The `.Thing` on which the connection is defined.
+
+        :return: the `.Thing` instance that is connected.
 
         :raises ThingNotConnectedError: if the ThingConnection has not yet been set up.
         """

--- a/src/labthings_fastapi/thing_connections.py
+++ b/src/labthings_fastapi/thing_connections.py
@@ -41,10 +41,9 @@ typed and documented on the class, i.e.
             return self.thing_a.say_hello()
 """
 
-import types
-from typing import Any, Generic, TypeVar, TYPE_CHECKING
+from types import EllipsisType, NoneType, UnionType
+from typing import Any, Generic, TypeVar, TYPE_CHECKING, Union, get_args, get_origin
 from collections.abc import Mapping, Sequence
-import typing
 from weakref import ReferenceType, WeakKeyDictionary, ref, WeakValueDictionary
 from .base_descriptor import FieldTypedBaseDescriptor
 from .exceptions import ThingNotConnectedError, ThingConnectionError
@@ -101,7 +100,9 @@ class ThingConnection(
             things: Mapping[str, OtherExample] = lt.thing_connection(["thing_a"])
     """
 
-    def __init__(self, *, default: str | None | Sequence[str] = None) -> None:
+    def __init__(
+        self, *, default: str | None | Sequence[str] | EllipsisType = ...
+    ) -> None:
         """Declare a ThingConnection.
 
         :param default: The name of the Thing(s) that will be connected by default.
@@ -135,19 +136,19 @@ class ThingConnection(
             return self.value_type
         # is_mapping already checks the type is a `Mapping`, so
         # we can just look at its arguments.
-        _, thing_type = typing.get_args(self.value_type)
+        _, thing_type = get_args(self.value_type)
         return thing_type
 
     @property
     def is_mapping(self) -> bool:
         """Whether we return a mapping of strings to Things, or a single Thing."""
-        return typing.get_origin(self.value_type) is Mapping
+        return get_origin(self.value_type) is Mapping
 
     @property
     def is_optional(self) -> bool:
         """Whether ``None`` or an empty mapping is an allowed value."""
-        if typing.get_origin(self.value_type) in (types.UnionType, typing.Union):
-            if types.NoneType in typing.get_args(self.value_type):
+        if get_origin(self.value_type) in (UnionType, Union):
+            if NoneType in get_args(self.value_type):
                 return True
         return False
 

--- a/src/labthings_fastapi/thing_connections.py
+++ b/src/labthings_fastapi/thing_connections.py
@@ -336,12 +336,12 @@ class ThingConnection(
         if isinstance(val, ReferenceType):
             thing = val()
             if thing is not None:
-                return thing  # type: ignore[return-value]
+                return thing  # type: ignore[return-value] (see docstring)
             else:
                 raise ReferenceError("A connected thing was garbage collected.")
         else:
             # This works for None or for WeakValueDictionary()
-            return val  # type: ignore[return-value]
+            return val  # type: ignore[return-value] (see Typing notes in docstring)
 
 
 def thing_connection(default: str | Iterable[str] | None | EllipsisType = ...) -> Any:

--- a/src/labthings_fastapi/thing_server_interface.py
+++ b/src/labthings_fastapi/thing_server_interface.py
@@ -1,0 +1,168 @@
+r"""Interface between `.Thing` subclasses and the `.ThingServer`\ ."""
+
+from __future__ import annotations
+import os
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING, Any, Awaitable, TypeVar
+from weakref import ref, ReferenceType
+
+from .exceptions import ServerNotRunningError
+
+if TYPE_CHECKING:
+    from .server import ThingServer
+    from .thing import Thing
+
+
+class ThingServerMissingError(RuntimeError):
+    """The error raised when a ThingServer is no longer available.
+
+    This error indicates that a ThingServerInterface is still in use
+    even though its underlying ThingServer has been deleted. This is
+    unlikely to happen and usually indicates that the server has
+    been created in an odd way.
+    """
+
+
+class ThingServerInterface:
+    r"""An interface for Things to interact with their server.
+
+    This is added to every `.Thing` during ``__init__`` and is available
+    as ``self._thing_server_interface``\ .
+    """
+
+    def __init__(self, server: ThingServer, name: str) -> None:
+        """Initialise a ThingServerInterface.
+
+        The ThingServerInterface sits between a Thing and its ThingServer,
+        with the intention of providing a useful set of functions, without
+        exposing too much of the server to the Thing.
+
+        One reason for using this intermediary class is to make it easier
+        to mock the server during testing: only functions provided here
+        need be mocked, not the whole functionality of the server.
+
+        :param server: the `.ThingServer` instance we're connected to.
+            This will be retained as a weak reference.
+        :param name: the name of the `.Thing` instance this interface
+            is provided for.
+        """
+        self._name: str = name
+        self._server: ReferenceType[ThingServer] = ref(server)
+
+    def _get_server(self) -> ThingServer:
+        """Return a live reference to the ThingServer.
+
+        This will evaluate the weak reference to the ThingServer, and will
+        raise an exception if the server has been garbage collected.
+
+        The server is, in practice, not going to be finalized before the
+        Things, so this should not be a problem.
+
+        :returns: the ThingServer.
+
+        :raises ThingServerMissingError: if the `ThingServer` is no longer
+            available.
+        """
+        server = self._server()
+        if server is None:
+            raise ThingServerMissingError()
+        return server
+
+    def start_async_task_soon(self, async_function: Awaitable, *args: Any) -> None:
+        """Run an asynchronous task in the server's event loop.
+
+        This function wraps `anyio.from_thread.BlockingPortal.start_task_soon` to
+        provide a way of calling asynchronous code from threaded code. It will
+        call the provided async function in the server's event loop, without any
+        guarantee of exactly when it will happen. This means we will return
+        immediately, and the return value from ``async_function`` will not be
+        available.
+
+        :param async_function: the asynchronous function to call.
+        :param *args: positional arguments to be provided to the function.
+        """
+        portal = self._get_server().blocking_portal
+        if portal is None:
+            raise ServerNotRunningError("Can't run async code without an event loop.")
+        portal.start_task_soon(async_function, *args)
+
+    @property
+    def settings_folder(self) -> str:
+        """The path to a folder where persistent files may be saved."""
+        server = self._get_server()
+        return os.path.join(server.settings_folder, self.name)
+
+    @property
+    def settings_file_path(self) -> str:
+        """The path where settings should be loaded and saved as JSON."""
+        return os.path.join(self.settings_folder, "settings.json")
+
+    @property
+    def name(self) -> str:
+        """The name of the Thing attached to this interface."""
+        return self._name
+
+    @property
+    def path(self) -> str:
+        """The path, relative to the server's base URL, of the Thing.
+
+        A ThingServerInterface is specific to one Thing, so this path points
+        to the base URL of the Thing, i.e. the Thing Description's endpoint.
+        """
+        return f"/{self.name}/"
+
+
+class MockThingServerInterface(ThingServerInterface):
+    """A mock class that simulates a ThingServerInterface without the server."""
+
+    def __init__(self, name: str) -> None:
+        """Initialise a ThingServerInterface.
+
+        :param name: The name of the Thing we're providing an interface to.
+        """
+        # We deliberately don't call super().__init__(), as it won't work without
+        # a server.
+        self._name: str = name
+        self._settings_tempdir: TemporaryDirectory | None = None
+
+    def start_async_task_soon(self, async_function: Awaitable, *args: Any) -> None:
+        """Do nothing, as there's no event loop to use.
+
+        :param async_function: the asynchronous function to call.
+        :param *args: positional arguments to be provided to the function.
+        """
+        pass
+
+    @property
+    def settings_folder(self) -> str:
+        """The path to a folder where persistent files may be saved."""
+        if not self._settings_tempdir:
+            self._settings_tempdir = TemporaryDirectory()
+        return self._settings_tempdir.name
+
+
+ThingSubclass = TypeVar("ThingSubclass", bound="Thing")
+
+
+def create_thing_without_server(
+    cls: type[ThingSubclass], *args: Any, **kwargs: Any
+) -> ThingSubclass:
+    r"""Create a `.Thing` and supply a mock ThingServerInterface.
+
+    This function is intended for use in testing, where it will enable a `.Thing`
+    to be created without a server, by supplying a `.MockThingServerInterface`
+    instead of a real `.ThingServerInterface`\ .
+
+    The name of the Thing will be taken from the class name, lowercased.
+
+    :param cls: The `.Thing` subclass to instantiate.
+    :param *args: positional arguments to ``__init__``.
+    :param **kwargs: keyword arguments to ``__init__``.
+
+    :returns: an instance of ``cls`` with a `.MockThingServerInterface`
+        so that it will function without a server.
+    """
+    name = cls.__name__.lower()
+    return cls(
+        *args, **kwargs, thing_server_interface=MockThingServerInterface(name=name)
+    )

--- a/src/labthings_fastapi/thing_server_interface.py
+++ b/src/labthings_fastapi/thing_server_interface.py
@@ -152,6 +152,10 @@ class MockThingServerInterface(ThingServerInterface):
             self._settings_tempdir = TemporaryDirectory()
         return self._settings_tempdir.name
 
+    def get_thing_states(self) -> Mapping[str, Any]:
+        """Return an empty dictionary to mock the metadata dictionary."""
+        return {}
+
 
 ThingSubclass = TypeVar("ThingSubclass", bound="Thing")
 

--- a/src/labthings_fastapi/thing_server_interface.py
+++ b/src/labthings_fastapi/thing_server_interface.py
@@ -122,7 +122,7 @@ class ThingServerInterface:
         A ThingServerInterface is specific to one Thing, so this path points
         to the base URL of the Thing, i.e. the Thing Description's endpoint.
         """
-        return f"/{self.name}/"
+        return self._get_server().path_for_thing(self.name)
 
     def get_thing_states(self) -> Mapping[str, Any]:
         """Retrieve metadata from all Things on the server.
@@ -186,6 +186,15 @@ class MockThingServerInterface(ThingServerInterface):
         if not self._settings_tempdir:
             self._settings_tempdir = TemporaryDirectory()
         return self._settings_tempdir.name
+
+    @property
+    def path(self) -> str:
+        """The path, relative to the server's base URL, of the Thing.
+
+        A ThingServerInterface is specific to one Thing, so this path points
+        to the base URL of the Thing, i.e. the Thing Description's endpoint.
+        """
+        return f"/{self.name}/"
 
     def get_thing_states(self) -> Mapping[str, Any]:
         """Return an empty dictionary to mock the metadata dictionary.

--- a/src/labthings_fastapi/thing_server_interface.py
+++ b/src/labthings_fastapi/thing_server_interface.py
@@ -3,7 +3,7 @@ r"""Interface between `.Thing` subclasses and the `.ThingServer`\ ."""
 from __future__ import annotations
 import os
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Any, Awaitable, TypeVar
+from typing import TYPE_CHECKING, Any, Awaitable, Mapping, TypeVar
 from weakref import ref, ReferenceType
 
 from .exceptions import ServerNotRunningError
@@ -110,6 +110,18 @@ class ThingServerInterface:
         to the base URL of the Thing, i.e. the Thing Description's endpoint.
         """
         return f"/{self.name}/"
+
+    def get_thing_states(self) -> Mapping[str, Any]:
+        """Retrieve metadata from all Things on the server.
+
+        This function will retrieve the `.Thing.thing_state` property from
+        each `.Thing` on the server, and return it as a dictionary.
+        It is intended to make it easy to add metadata to the results
+        of actions, for example to embed in an image.
+
+        :return: a dictionary of metadata, with the `.Thing` names as keys.
+        """
+        return {k: v.thing_state for k, v in self._get_server().things.items()}
 
 
 class MockThingServerInterface(ThingServerInterface):

--- a/src/labthings_fastapi/utilities/__init__.py
+++ b/src/labthings_fastapi/utilities/__init__.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, Iterable, TYPE_CHECKING, Optional
 from weakref import WeakSet
 from pydantic import BaseModel, ConfigDict, Field, RootModel, create_model
 from pydantic.dataclasses import dataclass
-from anyio.from_thread import BlockingPortal
 from .introspection import EmptyObject
 
 if TYPE_CHECKING:
@@ -80,25 +79,6 @@ def labthings_data(obj: Thing) -> LabThingsObjectData:
     if LABTHINGS_DICT_KEY not in obj.__dict__:
         obj.__dict__[LABTHINGS_DICT_KEY] = LabThingsObjectData()
     return obj.__dict__[LABTHINGS_DICT_KEY]
-
-
-def get_blocking_portal(obj: Thing) -> Optional[BlockingPortal]:
-    """Retrieve a blocking portal from a Thing.
-
-    See :ref:`concurrency` for more details.
-
-    When a `.Thing` is attached to a `.ThingServer` and the `.ThingServer`
-    is started, it sets an attribute on each `.Thing` to allow it to
-    access an `anyio.from_thread.BlockingPortal`. This allows threaded
-    code to call async code.
-
-    This function retrieves the blocking portal from a `.Thing`.
-
-    :param obj: the `.Thing` on which we are looking for the portal.
-
-    :return: the blocking portal.
-    """
-    return obj._labthings_blocking_portal
 
 
 def wrap_plain_types_in_rootmodel(model: type) -> type[BaseModel]:

--- a/tests/test_action_cancel.py
+++ b/tests/test_action_cancel.py
@@ -3,6 +3,7 @@ This tests the log that is returned in an action invocation
 """
 
 import uuid
+import pytest
 from fastapi.testclient import TestClient
 from .temp_client import poll_task, task_href
 import labthings_fastapi as lt
@@ -68,136 +69,136 @@ class CancellableCountingThing(lt.Thing):
             self.counter += counting_increment
 
 
-def test_invocation_cancel():
+@pytest.fixture
+def server():
+    """Create a server with a CancellableCountingThing added."""
+    server = lt.ThingServer()
+    server.add_thing("counting_thing", CancellableCountingThing)
+    return server
+
+
+@pytest.fixture
+def counting_thing(server):
+    """Retrieve the CancellableCountingThing from the server."""
+    return server.things["counting_thing"]
+
+
+@pytest.fixture
+def client(server):
+    with TestClient(server.app) as client:
+        yield client
+
+
+def test_invocation_cancel(counting_thing, client):
     """
     Test that an invocation can be cancelled and the associated
     exception handled correctly.
     """
-    server = lt.ThingServer()
-    counting_thing = CancellableCountingThing()
-    server.add_thing(counting_thing, "/counting_thing")
-    with TestClient(server.app) as client:
-        assert counting_thing.counter == 0
-        assert not counting_thing.check
-        response = client.post("/counting_thing/count_slowly", json={})
-        response.raise_for_status()
-        # Use `client.delete` to cancel the task!
-        cancel_response = client.delete(task_href(response.json()))
-        # Raise an exception is this isn't a 2xx response
-        cancel_response.raise_for_status()
-        invocation = poll_task(client, response.json())
-        assert invocation["status"] == "cancelled"
-        assert counting_thing.counter < 9
-        # Check that error handling worked
-        assert counting_thing.check
+    assert counting_thing.counter == 0
+    assert not counting_thing.check
+    response = client.post("/counting_thing/count_slowly", json={})
+    response.raise_for_status()
+    # Use `client.delete` to cancel the task!
+    cancel_response = client.delete(task_href(response.json()))
+    # Raise an exception is this isn't a 2xx response
+    cancel_response.raise_for_status()
+    invocation = poll_task(client, response.json())
+    assert invocation["status"] == "cancelled"
+    assert counting_thing.counter < 9
+    # Check that error handling worked
+    assert counting_thing.check
 
 
-def test_invocation_that_refuses_to_cancel():
+def test_invocation_that_refuses_to_cancel(counting_thing, client):
     """
     Test that an invocation can detect a cancel request but choose
     to modify behaviour.
     """
-    server = lt.ThingServer()
-    counting_thing = CancellableCountingThing()
-    server.add_thing(counting_thing, "/counting_thing")
-    with TestClient(server.app) as client:
-        assert counting_thing.counter == 0
-        response = client.post(
-            "/counting_thing/count_slowly_but_ignore_cancel", json={"n": 5}
-        )
-        response.raise_for_status()
-        # Use `client.delete` to try to cancel the task!
-        cancel_response = client.delete(task_href(response.json()))
-        # Raise an exception is this isn't a 2xx response
-        cancel_response.raise_for_status()
-        invocation = poll_task(client, response.json())
-        # As the task ignored the cancel. It should return completed
-        assert invocation["status"] == "completed"
-        # Counter should be greater than 5 as it counts faster if cancelled!
-        assert counting_thing.counter > 5
+    assert counting_thing.counter == 0
+    response = client.post(
+        "/counting_thing/count_slowly_but_ignore_cancel", json={"n": 5}
+    )
+    response.raise_for_status()
+    # Use `client.delete` to try to cancel the task!
+    cancel_response = client.delete(task_href(response.json()))
+    # Raise an exception is this isn't a 2xx response
+    cancel_response.raise_for_status()
+    invocation = poll_task(client, response.json())
+    # As the task ignored the cancel. It should return completed
+    assert invocation["status"] == "completed"
+    # Counter should be greater than 5 as it counts faster if cancelled!
+    assert counting_thing.counter > 5
 
 
-def test_invocation_that_needs_cancel_twice():
+def test_invocation_that_needs_cancel_twice(counting_thing, client):
     """
     Test that an invocation can interpret cancel to change behaviour, but
     can really cancel if requested a second time
     """
-    server = lt.ThingServer()
-    counting_thing = CancellableCountingThing()
-    server.add_thing(counting_thing, "/counting_thing")
-    with TestClient(server.app) as client:
-        # First cancel only once:
-        assert counting_thing.counter == 0
-        response = client.post(
-            "/counting_thing/count_and_only_cancel_if_asked_twice", json={"n": 5}
-        )
-        response.raise_for_status()
-        # Use `client.delete` to try to cancel the task!
-        cancel_response = client.delete(task_href(response.json()))
-        # Raise an exception is this isn't a 2xx response
-        cancel_response.raise_for_status()
-        invocation = poll_task(client, response.json())
-        # As the task ignored the cancel. It should return completed
-        assert invocation["status"] == "completed"
-        # Counter should be less than 0 as it should started counting backwards
-        # almost immediately.
-        assert counting_thing.counter < 0
+    # First cancel only once:
+    assert counting_thing.counter == 0
+    response = client.post(
+        "/counting_thing/count_and_only_cancel_if_asked_twice", json={"n": 5}
+    )
+    response.raise_for_status()
+    # Use `client.delete` to try to cancel the task!
+    cancel_response = client.delete(task_href(response.json()))
+    # Raise an exception is this isn't a 2xx response
+    cancel_response.raise_for_status()
+    invocation = poll_task(client, response.json())
+    # As the task ignored the cancel. It should return completed
+    assert invocation["status"] == "completed"
+    # Counter should be less than 0 as it should started counting backwards
+    # almost immediately.
+    assert counting_thing.counter < 0
 
-        # Next cancel twice.
-        counting_thing.counter = 0
-        assert counting_thing.counter == 0
-        response = client.post(
-            "/counting_thing/count_and_only_cancel_if_asked_twice", json={"n": 5}
-        )
-        response.raise_for_status()
-        # Use `client.delete` to try to cancel the task!
-        cancel_response = client.delete(task_href(response.json()))
-        # Raise an exception is this isn't a 2xx response
-        cancel_response.raise_for_status()
-        # Cancel again
-        cancel_response2 = client.delete(task_href(response.json()))
-        # Raise an exception is this isn't a 2xx response
-        cancel_response2.raise_for_status()
-        invocation = poll_task(client, response.json())
-        # As the task ignored the cancel. It should return completed
-        assert invocation["status"] == "cancelled"
-        # Counter should be less than 0 as it should started counting backwards
-        # almost immediately.
-        assert counting_thing.counter < 0
+    # Next cancel twice.
+    counting_thing.counter = 0
+    assert counting_thing.counter == 0
+    response = client.post(
+        "/counting_thing/count_and_only_cancel_if_asked_twice", json={"n": 5}
+    )
+    response.raise_for_status()
+    # Use `client.delete` to try to cancel the task!
+    cancel_response = client.delete(task_href(response.json()))
+    # Raise an exception is this isn't a 2xx response
+    cancel_response.raise_for_status()
+    # Cancel again
+    cancel_response2 = client.delete(task_href(response.json()))
+    # Raise an exception is this isn't a 2xx response
+    cancel_response2.raise_for_status()
+    invocation = poll_task(client, response.json())
+    # As the task ignored the cancel. It should return completed
+    assert invocation["status"] == "cancelled"
+    # Counter should be less than 0 as it should started counting backwards
+    # almost immediately.
+    assert counting_thing.counter < 0
 
 
-def test_late_invocation_cancel_responds_503():
+def test_late_invocation_cancel_responds_503(counting_thing, client):
     """
     Test that cancelling an invocation after it completes returns a 503 response.
     """
-    server = lt.ThingServer()
-    counting_thing = CancellableCountingThing()
-    server.add_thing(counting_thing, "/counting_thing")
-    with TestClient(server.app) as client:
-        assert counting_thing.counter == 0
-        assert not counting_thing.check
-        response = client.post("/counting_thing/count_slowly", json={"n": 1})
-        response.raise_for_status()
-        # Sleep long enough that task completes.
-        time.sleep(0.3)
-        poll_task(client, response.json())
-        # Use `client.delete` to cancel the task!
-        cancel_response = client.delete(task_href(response.json()))
-        # Check a 503 code is returned
-        assert cancel_response.status_code == 503
-        # Check counter reached it's target
-        assert counting_thing.counter == 1
-        # Check that error handling wasn't called
-        assert not counting_thing.check
+    assert counting_thing.counter == 0
+    assert not counting_thing.check
+    response = client.post("/counting_thing/count_slowly", json={"n": 1})
+    response.raise_for_status()
+    # Sleep long enough that task completes.
+    time.sleep(0.3)
+    poll_task(client, response.json())
+    # Use `client.delete` to cancel the task!
+    cancel_response = client.delete(task_href(response.json()))
+    # Check a 503 code is returned
+    assert cancel_response.status_code == 503
+    # Check counter reached it's target
+    assert counting_thing.counter == 1
+    # Check that error handling wasn't called
+    assert not counting_thing.check
 
 
-def test_cancel_unknown_task():
+def test_cancel_unknown_task(counting_thing, client):
     """
     Test that cancelling an unknown invocation returns a 404 response
     """
-    server = lt.ThingServer()
-    counting_thing = CancellableCountingThing()
-    server.add_thing(counting_thing, "/counting_thing")
-    with TestClient(server.app) as client:
-        cancel_response = client.delete(f"/invocations/{uuid.uuid4()}")
-        assert cancel_response.status_code == 404
+    cancel_response = client.delete(f"/invocations/{uuid.uuid4()}")
+    assert cancel_response.status_code == 404

--- a/tests/test_action_logging.py
+++ b/tests/test_action_logging.py
@@ -4,6 +4,7 @@ This tests the log that is returned in an action invocation
 
 import logging
 from fastapi.testclient import TestClient
+import pytest
 from .temp_client import poll_task
 import labthings_fastapi as lt
 from labthings_fastapi.actions.invocation_model import LogRecordModel
@@ -29,53 +30,54 @@ class ThingThatLogsAndErrors(lt.Thing):
         raise lt.exceptions.InvocationError("This is an error, but I handled it!")
 
 
-def test_invocation_logging(caplog):
+@pytest.fixture
+def client():
+    """Set up a Thing Server and yield a client to it."""
+    server = lt.ThingServer()
+    server.add_thing("log_and_error_thing", ThingThatLogsAndErrors)
+    with TestClient(server.app) as client:
+        yield client
+
+
+def test_invocation_logging(caplog, client):
+    """Check the expected items appear in the log when an action is invoked."""
     with caplog.at_level(logging.INFO, logger="labthings.action"):
-        server = lt.ThingServer()
-        server.add_thing(ThingThatLogsAndErrors(), "/log_and_error_thing")
-        with TestClient(server.app) as client:
-            r = client.post("/log_and_error_thing/action_that_logs")
-            r.raise_for_status()
-            invocation = poll_task(client, r.json())
-            assert invocation["status"] == "completed"
-            assert len(invocation["log"]) == len(ThingThatLogsAndErrors.LOG_MESSAGES)
-            assert len(invocation["log"]) == len(caplog.records)
-            for expected, entry in zip(
-                ThingThatLogsAndErrors.LOG_MESSAGES, invocation["log"], strict=True
-            ):
-                assert entry["message"] == expected
+        r = client.post("/log_and_error_thing/action_that_logs")
+        r.raise_for_status()
+        invocation = poll_task(client, r.json())
+        assert invocation["status"] == "completed"
+        assert len(invocation["log"]) == len(ThingThatLogsAndErrors.LOG_MESSAGES)
+        assert len(invocation["log"]) == len(caplog.records)
+        for expected, entry in zip(
+            ThingThatLogsAndErrors.LOG_MESSAGES, invocation["log"], strict=True
+        ):
+            assert entry["message"] == expected
 
 
-def test_unhandled_error_logs(caplog):
+def test_unhandled_error_logs(caplog, client):
     """Check that a log with a traceback is raised if there is an unhandled error."""
     with caplog.at_level(logging.INFO, logger="labthings.action"):
-        server = lt.ThingServer()
-        server.add_thing(ThingThatLogsAndErrors(), "/log_and_error_thing")
-        with TestClient(server.app) as client:
-            r = client.post("/log_and_error_thing/action_with_unhandled_error")
-            r.raise_for_status()
-            invocation = poll_task(client, r.json())
-            assert invocation["status"] == "error"
-            assert len(invocation["log"]) == len(caplog.records) == 1
-            assert caplog.records[0].levelname == "ERROR"
-            # There is a traceback
-            assert caplog.records[0].exc_info is not None
+        r = client.post("/log_and_error_thing/action_with_unhandled_error")
+        r.raise_for_status()
+        invocation = poll_task(client, r.json())
+        assert invocation["status"] == "error"
+        assert len(invocation["log"]) == len(caplog.records) == 1
+        assert caplog.records[0].levelname == "ERROR"
+        # There is a traceback
+        assert caplog.records[0].exc_info is not None
 
 
-def test_invocation_error_logs(caplog):
+def test_invocation_error_logs(caplog, client):
     """Check that a log with a traceback is raised if there is an unhandled error."""
     with caplog.at_level(logging.INFO, logger="labthings.action"):
-        server = lt.ThingServer()
-        server.add_thing(ThingThatLogsAndErrors(), "/log_and_error_thing")
-        with TestClient(server.app) as client:
-            r = client.post("/log_and_error_thing/action_with_invocation_error")
-            r.raise_for_status()
-            invocation = poll_task(client, r.json())
-            assert invocation["status"] == "error"
-            assert len(invocation["log"]) == len(caplog.records) == 1
-            assert caplog.records[0].levelname == "ERROR"
-            # There is not a traceback
-            assert caplog.records[0].exc_info is None
+        r = client.post("/log_and_error_thing/action_with_invocation_error")
+        r.raise_for_status()
+        invocation = poll_task(client, r.json())
+        assert invocation["status"] == "error"
+        assert len(invocation["log"]) == len(caplog.records) == 1
+        assert caplog.records[0].levelname == "ERROR"
+        # There is not a traceback
+        assert caplog.records[0].exc_info is None
 
 
 def test_logrecordmodel():

--- a/tests/test_action_manager.py
+++ b/tests/test_action_manager.py
@@ -25,12 +25,16 @@ class CounterThing(lt.Thing):
     "A pointless counter"
 
 
-thing = CounterThing()
-server = lt.ThingServer()
-server.add_thing(thing, "/thing")
+@pytest.fixture
+def client():
+    """Yield a TestClient connected to a ThingServer."""
+    server = lt.ThingServer()
+    server.add_thing("thing", CounterThing)
+    with TestClient(server.app) as client:
+        yield client
 
 
-def test_action_expires():
+def test_action_expires(client):
     """Check the action is removed from the server
 
     We've set the retention period to be very short, so the action
@@ -44,23 +48,22 @@ def test_action_expires():
     This behaviour might change in the future, making the second run
     unnecessary.
     """
-    with TestClient(server.app) as client:
-        before_value = client.get("/thing/counter").json()
-        r = client.post("/thing/increment_counter")
-        invocation = poll_task(client, r.json())
-        time.sleep(0.02)
-        r2 = client.post("/thing/increment_counter")
-        poll_task(client, r2.json())
-        after_value = client.get("/thing/counter").json()
-        assert after_value == before_value + 2
-        invocation["status"] = "running"  # Force an extra poll
-        # When the second action runs, the first one should expire
-        # so polling it again should give a 404.
-        with pytest.raises(httpx.HTTPStatusError):
-            poll_task(client, invocation)
+    before_value = client.get("/thing/counter").json()
+    r = client.post("/thing/increment_counter")
+    invocation = poll_task(client, r.json())
+    time.sleep(0.02)
+    r2 = client.post("/thing/increment_counter")
+    poll_task(client, r2.json())
+    after_value = client.get("/thing/counter").json()
+    assert after_value == before_value + 2
+    invocation["status"] = "running"  # Force an extra poll
+    # When the second action runs, the first one should expire
+    # so polling it again should give a 404.
+    with pytest.raises(httpx.HTTPStatusError):
+        poll_task(client, invocation)
 
 
-def test_actions_list():
+def test_actions_list(client):
     """Check that the /action_invocations/ path works.
 
     The /action_invocations/ path should return a list of invocation
@@ -68,10 +71,9 @@ def test_actions_list():
 
     It's implemented in `ActionManager.list_all_invocations`.
     """
-    with TestClient(server.app) as client:
-        r = client.post("/thing/increment_counter_longlife")
-        invocation = poll_task(client, r.json())
-        r2 = client.get(ACTION_INVOCATIONS_PATH)
-        r2.raise_for_status()
-        invocations = r2.json()
-        assert invocations == [invocation]
+    r = client.post("/thing/increment_counter_longlife")
+    invocation = poll_task(client, r.json())
+    r2 = client.get(ACTION_INVOCATIONS_PATH)
+    r2.raise_for_status()
+    invocations = r2.json()
+    assert invocations == [invocation]

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -3,7 +3,7 @@ from fastapi.testclient import TestClient
 import pytest
 import functools
 
-from labthings_fastapi.exceptions import NotConnectedToServerError
+from labthings_fastapi.thing_server_interface import create_thing_without_server
 from .temp_client import poll_task, get_link
 from labthings_fastapi.example_things import MyThing
 import labthings_fastapi as lt
@@ -198,19 +198,5 @@ def test_wrapped_action():
     assert Example.action.output_model == Example.decorated.output_model
 
     # Check we can make the thing and it has a valid TD
-    example = Example()
-    example.path = "/example"
+    example = create_thing_without_server(Example)
     example.validate_thing_description()
-
-
-def test_affordance_and_fastapi_errors(mocker):
-    """Check that we get a sensible error if the Thing has no path.
-
-    The thing will not have a ``path`` property before it has been added
-    to a server.
-    """
-    thing = MyThing()
-    with pytest.raises(NotConnectedToServerError):
-        MyThing.anaction.add_to_fastapi(mocker.Mock(), thing)
-    with pytest.raises(NotConnectedToServerError):
-        MyThing.anaction.action_affordance(thing, None)

--- a/tests/test_base_descriptor.py
+++ b/tests/test_base_descriptor.py
@@ -1,11 +1,14 @@
+import gc
 import pytest
 from labthings_fastapi.base_descriptor import (
     BaseDescriptor,
+    FieldTypedBaseDescriptor,
     DescriptorNotAddedToClassError,
     DescriptorAddedToClassTwiceError,
     get_class_attribute_docstrings,
 )
 from .utilities import raises_or_is_caused_by
+from labthings_fastapi.exceptions import MissingTypeError, InconsistentTypeError
 
 
 class MockProperty(BaseDescriptor[str]):
@@ -284,3 +287,164 @@ def test_decorator_different_names():
     assert "prop" in str(excinfo.value)
     assert "FirstExampleClass" in str(excinfo.value)
     assert "SecondExampleClass" in str(excinfo.value)
+
+
+class CustomType:
+    """A custom datatype."""
+
+    pass
+
+
+class FieldTypedExample:
+    """An example with field-typed descriptors."""
+
+    int_or_str_prop: int | str = FieldTypedBaseDescriptor()
+    int_or_str_subscript = FieldTypedBaseDescriptor[int | str]()
+    int_or_str_stringified: "int | str" = FieldTypedBaseDescriptor()
+    customprop: CustomType = FieldTypedBaseDescriptor()
+    customprop_subscript = FieldTypedBaseDescriptor[CustomType]()
+    futureprop: "FutureType" = FieldTypedBaseDescriptor()
+
+
+class FutureType:
+    """A custom datatype, defined after the descriptor."""
+
+    pass
+
+
+@pytest.mark.parametrize(
+    ("name", "value_type"),
+    [
+        ("int_or_str_prop", int | str),
+        ("int_or_str_subscript", int | str),
+        ("int_or_str_stringified", int | str),
+        ("customprop", CustomType),
+        ("customprop_subscript", CustomType),
+        ("futureprop", FutureType),
+    ],
+)
+def test_fieldtyped_definition(name, value_type):
+    """Test that field-typed descriptors pick up their type correctly."""
+    prop = getattr(FieldTypedExample, name)
+    assert prop.name == name
+    assert prop.value_type == value_type
+
+
+def test_fieldtyped_missingtype():
+    """Check the right error is raised when no type can be found."""
+    with pytest.raises(MissingTypeError) as excinfo:
+
+        class Example2:
+            field2 = FieldTypedBaseDescriptor()
+
+    msg = str(excinfo.value)
+    assert msg.startswith("No type hint was found")
+    # We check the field name is included, because the exception will
+    # arise from the end of the class definition, rather than the line
+    # where the field is defined.
+    assert "field2" in msg
+
+    # This one defines OK, but should error when we access its type.
+    # Note that Ruff already spots the bad forward reference, hence the
+    # directive to ignore F821.
+    class Example3:
+        field3: "BadForwardReference" = FieldTypedBaseDescriptor()  # noqa: F821
+        field4: "int" = FieldTypedBaseDescriptor()
+        field5: "int" = FieldTypedBaseDescriptor()
+
+    with pytest.raises(MissingTypeError) as excinfo:
+        _ = Example3.field3.value_type
+
+    msg = str(excinfo.value)
+    assert "resolve forward ref" in msg
+    assert "field3" in msg
+
+    # If we try to resolve a forward reference and the owner is None, it
+    # should raise an error.
+    # I don't see how this could happen in practice, _owner is always
+    # set if we find a forward reference.
+    # We force this error condition by manually setting _owner to None
+    Example3.field4._owner = None
+
+    with pytest.raises(MissingTypeError) as excinfo:
+        _ = Example3.field4.value_type
+
+    msg = str(excinfo.value)
+    assert "resolve forward ref" in msg
+    assert "wasn't saved" in msg
+    assert "field4" in msg
+
+    # We re-use field4 but manually set _type and _unevaluated_type_hint
+    # to None, to test the catch-all error
+    Example3.field4._unevaluated_type_hint = None
+
+    with pytest.raises(MissingTypeError):
+        _ = Example3.field4.value_type
+
+    msg = str(excinfo.value)
+    assert "bug in LabThings" in msg
+    assert "caught before now" in msg
+    assert "field4" in msg
+
+    # If the class is finalised before we evaluate type hints, we should
+    # get a MissingTypeError. This probably only happens on dynamically
+    # generated classes, and I think it's unlikely we'd dynamically generate
+    # Thing subclasses in a way that they go out of scope.
+    prop = Example3.field5
+    del Example3
+    gc.collect()
+
+    with pytest.raises(MissingTypeError) as excinfo:
+        _ = prop.value_type
+
+    msg = str(excinfo.value)
+    assert "resolve forward ref" in msg
+    assert "garbage collected" in msg
+    assert "field5" in msg
+
+    # Rather than roll my own evaluator for forward references, we just
+    # won't support forward references in subscripted types for now.
+    with pytest.raises(MissingTypeError) as excinfo:
+
+        class Example4:
+            field6 = FieldTypedBaseDescriptor["str"]()
+
+    msg = str(excinfo.value)
+    assert "forward reference" in msg
+    assert "not supported as subscripts"
+    assert "field6" in msg
+
+
+def test_mismatched_types():
+    """Check two type hints that don't match raises an error."""
+    with pytest.raises(InconsistentTypeError):
+
+        class Example3:
+            field: int = FieldTypedBaseDescriptor[str]()
+
+
+def test_double_specified_types():
+    """Check two type hints that match are allowed.
+
+    This is a very odd thing to do, but it feels right to allow
+    it, provided the types are an exact match.
+    """
+
+    class Example4:
+        field: int | None = FieldTypedBaseDescriptor[int | None]()
+
+    assert Example4.field.value_type == int | None
+
+
+def test_stringified_vs_unstringified_mismatch():
+    """Test that string type hints don't match non-string ones.
+
+    This behaviour may change in the future - but this test is here
+    to make sure that, if it does, we are changing it deliberately.
+    If a descriptor is typed using both a subscript and a field
+    annotation, they should match -
+    """
+    with pytest.raises(InconsistentTypeError):
+
+        class Example5:
+            field: "int" = FieldTypedBaseDescriptor[int]()

--- a/tests/test_blob_output.py
+++ b/tests/test_blob_output.py
@@ -8,6 +8,7 @@ from tempfile import TemporaryDirectory
 from fastapi.testclient import TestClient
 import pytest
 import labthings_fastapi as lt
+from labthings_fastapi.thing_server_interface import create_thing_without_server
 
 
 class TextBlob(lt.blob.Blob):
@@ -17,7 +18,8 @@ class TextBlob(lt.blob.Blob):
 class ThingOne(lt.Thing):
     ACTION_ONE_RESULT = b"Action one result!"
 
-    def __init__(self):
+    def __init__(self, thing_server_interface):
+        super().__init__(thing_server_interface=thing_server_interface)
         self._temp_directory = TemporaryDirectory()
 
     @lt.thing_action
@@ -114,7 +116,7 @@ def test_blob_output_client(client):
 
 def test_blob_output_direct():
     """Check blob outputs work correctly when we use a Thing directly in Python."""
-    thing = ThingOne()
+    thing = create_thing_without_server(ThingOne)
     check_actions(thing)
 
 

--- a/tests/test_directthingclient.py
+++ b/tests/test_directthingclient.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 import pytest
 import labthings_fastapi as lt
 from labthings_fastapi.deps import DirectThingClient, direct_thing_client_class
+from labthings_fastapi.thing_server_interface import create_thing_without_server
 from .temp_client import poll_task
 
 
@@ -40,10 +41,9 @@ def counter_client(mocker) -> DirectThingClient:
     :param mocker: the mocker test fixture from ``pytest-mock``\ .
     :returns: a ``DirectThingClient`` subclass wrapping a ``Counter``\ .
     """
-    counter = Counter()
-    counter._labthings_blocking_portal = mocker.Mock(["start_task_soon"])
+    counter = create_thing_without_server(Counter)
 
-    CounterClient = direct_thing_client_class(Counter, "/counter")
+    CounterClient = direct_thing_client_class(Counter, "counter")
 
     class StandaloneCounterClient(CounterClient):
         def __init__(self, wrapped):

--- a/tests/test_directthingclient.py
+++ b/tests/test_directthingclient.py
@@ -54,7 +54,7 @@ def counter_client(mocker) -> DirectThingClient:
     return StandaloneCounterClient(counter)
 
 
-CounterDep = lt.deps.direct_thing_client_dependency(Counter, "/counter/")
+CounterDep = lt.deps.direct_thing_client_dependency(Counter, "counter")
 RawCounterDep = lt.deps.raw_thing_dependency(Counter)
 
 
@@ -145,8 +145,8 @@ def test_directthingclient_in_server(action):
     This uses the internal thing client mechanism.
     """
     server = lt.ThingServer()
-    server.add_thing(Counter(), "/counter")
-    server.add_thing(Controller(), "/controller")
+    server.add_thing("counter", Counter)
+    server.add_thing("controller", Controller)
     with TestClient(server.app) as client:
         r = client.post(f"/controller/{action}")
         invocation = poll_task(client, r.json())

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from runpy import run_path
 from fastapi.testclient import TestClient
+import pytest
 from labthings_fastapi import ThingClient
 from .test_server_cli import MonitoredProcess
 
@@ -18,6 +19,7 @@ def run_quickstart_counter():
     run_path(str(docs / "quickstart" / "counter.py"))
 
 
+@pytest.mark.slow
 def test_quickstart_counter():
     """Check we can create a server from the command line"""
     p = MonitoredProcess(target=run_quickstart_counter)

--- a/tests/test_endpoint_decorator.py
+++ b/tests/test_endpoint_decorator.py
@@ -1,6 +1,5 @@
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
-import pytest
 import labthings_fastapi as lt
 
 
@@ -50,15 +49,3 @@ def test_endpoints():
         r = client.post("/thing/path_from_path", json={"a": 1, "b": 2})
         r.raise_for_status()
         assert r.json() == "post_method 1 2"
-
-
-def test_endpoint_notconnected(mocker):
-    """Check for the correct error if we add endpoints prematurely.
-
-    We should get this error if we call ``add_to_fastapi`` on an endpoint
-    where the `.Thing` does not have a valid ``path`` attribute.
-    """
-    thing = MyThing()
-
-    with pytest.raises(lt.exceptions.NotConnectedToServerError):
-        MyThing.get_method.add_to_fastapi(mocker.Mock(), thing)

--- a/tests/test_endpoint_decorator.py
+++ b/tests/test_endpoint_decorator.py
@@ -26,8 +26,8 @@ class MyThing(lt.Thing):
 def test_endpoints():
     """Check endpoints may be added to the app and work as expected."""
     server = lt.ThingServer()
-    thing = MyThing()
-    server.add_thing(thing, "/thing")
+    server.add_thing("thing", MyThing)
+    thing = server.things["thing"]
     with TestClient(server.app) as client:
         # Check the function works when used directly
         assert thing.path_from_name() == "path_from_name"

--- a/tests/test_example_thing.py
+++ b/tests/test_example_thing.py
@@ -6,21 +6,11 @@ from labthings_fastapi.example_things import (
 )
 import pytest
 
-
-class DummyBlockingPortal:
-    """A dummy blocking portal for testing
-
-    This is a blocking portal that doesn't actually do anything.
-    In the future, we should improve LabThings so this is not required.
-    """
-
-    def start_task_soon(self, func, *args, **kwargs):
-        pass
+from labthings_fastapi.thing_server_interface import create_thing_without_server
 
 
 def test_mything():
-    thing = MyThing()
-    thing._labthings_blocking_portal = DummyBlockingPortal()
+    thing = create_thing_without_server(MyThing)
     assert isinstance(thing, MyThing)
     assert thing.counter == 0
     ret = thing.anaction(3, 1, title="MyTitle", attempts=["a", "b", "c"])
@@ -40,7 +30,7 @@ def test_mything():
 
 
 def test_thing_with_broken_affordances():
-    thing = ThingWithBrokenAffordances()
+    thing = create_thing_without_server(ThingWithBrokenAffordances)
     assert isinstance(thing, ThingWithBrokenAffordances)
     with pytest.raises(RuntimeError):
         thing.broken_action()
@@ -50,11 +40,11 @@ def test_thing_with_broken_affordances():
 
 def test_thing_that_cannot_instantiate():
     with pytest.raises(RuntimeError):
-        ThingThatCantInstantiate()
+        create_thing_without_server(ThingThatCantInstantiate)
 
 
 def test_thing_that_cannot_start():
-    thing = ThingThatCantStart()
+    thing = create_thing_without_server(ThingThatCantStart)
     assert isinstance(thing, ThingThatCantStart)
     with pytest.raises(RuntimeError):
         with thing:

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -49,8 +49,8 @@ def test_fallback_with_server():
         html = response.text
         assert "Something went wrong" in html
         assert "No logging info available" in html
-        assert "thing1/" in html
-        assert "thing2/" in html
+        assert "thing1" in html
+        assert "thing2" in html
 
 
 def test_fallback_with_log():

--- a/tests/test_locking_decorator.py
+++ b/tests/test_locking_decorator.py
@@ -115,8 +115,8 @@ def echo_via_client(client):
 def test_locking_in_server():
     """Check the lock works within LabThings."""
     server = lt.ThingServer()
-    thing = LockedExample()
-    server.add_thing(thing, "/thing")
+    server.add_thing("thing", LockedExample)
+    thing = server.things["thing"]
     with TestClient(server.app) as client:
         # Start a long task
         r1 = client.post("/thing/wait_wrapper", json={})

--- a/tests/test_locking_decorator.py
+++ b/tests/test_locking_decorator.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 import pytest
 
 import labthings_fastapi as lt
+from labthings_fastapi.thing_server_interface import create_thing_without_server
 from .temp_client import poll_task
 
 
@@ -35,8 +36,9 @@ class LockedExample(lt.Thing):
 
     flag: bool = lt.property(default=False)
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         """Initialise the lock."""
+        super().__init__(**kwargs)
         self._lock = RLock()  # This lock is used by @requires_lock
         self._event = Event()  # This is used to keep tests quick
         # by stopping waits as soon as they are no longer needed
@@ -70,8 +72,7 @@ class LockedExample(lt.Thing):
 @pytest.fixture
 def thing(mocker) -> LockedExample:
     """Instantiate the LockedExample thing."""
-    thing = LockedExample()
-    thing._labthings_blocking_portal = mocker.Mock()
+    thing = create_thing_without_server(LockedExample)
     return thing
 
 

--- a/tests/test_mjpeg_stream.py
+++ b/tests/test_mjpeg_stream.py
@@ -36,12 +36,10 @@ class Telly(lt.Thing):
 
         i = 0
         while self._streaming and (i < self.frame_limit or self.frame_limit < 0):
-            self.stream.add_frame(
-                jpegs[i % len(jpegs)], self._labthings_blocking_portal
-            )
+            self.stream.add_frame(jpegs[i % len(jpegs)])
             time.sleep(1 / self.framerate)
             i = i + 1
-        self.stream.stop(self._labthings_blocking_portal)
+        self.stream.stop()
         self._streaming = False
 
 

--- a/tests/test_numpy_type.py
+++ b/tests/test_numpy_type.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pydantic import BaseModel, RootModel
 import numpy as np
 
+from labthings_fastapi.thing_server_interface import create_thing_without_server
 from labthings_fastapi.types.numpy import NDArray, DenumpifyingDict
 import labthings_fastapi as lt
 
@@ -63,19 +64,21 @@ def test_0d():
 
 
 class MyNumpyThing(lt.Thing):
+    """A thing that uses numpy types."""
+
     @lt.thing_action
     def action_with_arrays(self, a: NDArray) -> NDArray:
         return a * 2
 
 
 def test_thing_description():
-    thing = MyNumpyThing()
-    # We must mock a path, or it can't generate a Thing Description.
-    thing.path = "/mynumpything"
+    """Make sure the TD validates when numpy types are used."""
+    thing = create_thing_without_server(MyNumpyThing)
     assert thing.validate_thing_description() is None
 
 
 def test_denumpifying_dict():
+    """Check DenumpifyingDict converts arrays to lists."""
     d = DenumpifyingDict(
         root={
             "a": np.array([1, 2, 3]),
@@ -94,6 +97,7 @@ def test_denumpifying_dict():
 
 
 def test_rootmodel():
+    """Check that RootModels with NDArray convert between array and list."""
     for input in [[0, 1, 2], np.arange(3)]:
         m = ArrayModel(root=input)
         assert isinstance(m.root, np.ndarray)

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -53,9 +53,8 @@ class PropertyTestThing(lt.Thing):
 
 @pytest.fixture
 def server():
-    thing = PropertyTestThing()
     server = lt.ThingServer()
-    server.add_thing(thing, "/thing")
+    server.add_thing("thing", PropertyTestThing)
     return server
 
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,13 +1,11 @@
 from threading import Thread
 from typing import Any
 
-from pytest import raises
 from pydantic import BaseModel, RootModel
 from fastapi.testclient import TestClient
 import pytest
 
 import labthings_fastapi as lt
-from labthings_fastapi.exceptions import NotConnectedToServerError
 from .temp_client import poll_task
 
 
@@ -232,15 +230,3 @@ def test_setting_from_thread(server):
         r = client.get("/thing/boolprop")
         assert r.status_code == 200
         assert r.json() is True
-
-
-def test_setting_without_event_loop(server):
-    """Test that an exception is raised if updating a DataProperty
-    without connecting the Thing to a running server with an event loop.
-    """
-    # This test may need to change, if we change the intended behaviour
-    # Currently it should never be necessary to change properties from the
-    # main thread, so we raise an error if you try to do so
-    thing = PropertyTestThing()
-    with raises(NotConnectedToServerError):
-        thing.boolprop = False  # Can't call it until the event loop's running

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -155,22 +155,19 @@ def test_baseproperty_type_and_model():
     `pydantic.RootModel`.
     """
 
+    with pytest.raises(tp.MissingTypeError):
+
+        class Example:
+            prop = tp.BaseProperty()
+
     class Example:
-        prop = tp.BaseProperty()
+        prop: "str | None" = tp.BaseProperty()
 
-    prop = Example.prop
-
-    # By default, we have no type so `.type` errors.
-    with pytest.raises(tp.MissingTypeError):
-        _ = prop.value_type
-    with pytest.raises(tp.MissingTypeError):
-        _ = prop.model
-
-    # Once _type is set, these should both work.
-    prop._type = str | None
-    assert str(prop.value_type) == "str | None"
-    assert issubclass(prop.model, pydantic.RootModel)
-    assert str(prop.model.model_fields["root"].annotation) == "str | None"
+    assert isinstance(None, Example.prop.value_type)
+    assert isinstance("test", Example.prop.value_type)
+    assert str(Example.prop.value_type) == "str | None"
+    assert issubclass(Example.prop.model, pydantic.RootModel)
+    assert str(Example.prop.model.model_fields["root"].annotation) == "str | None"
 
 
 def test_baseproperty_type_and_model_pydantic():
@@ -180,19 +177,15 @@ def test_baseproperty_type_and_model_pydantic():
     type is a BaseModel instance.
     """
 
-    class Example:
-        prop = tp.BaseProperty()
-
-    prop = Example.prop
-
     class MyModel(pydantic.BaseModel):
         foo: str
         bar: int
 
-    # Once _type is set, these should both work.
-    prop._type = MyModel
-    assert prop.value_type is MyModel
-    assert prop.model is MyModel
+    class Example:
+        prop: MyModel = tp.BaseProperty()
+
+    assert Example.prop.value_type is MyModel
+    assert Example.prop.model is MyModel
 
 
 def test_baseproperty_add_to_fastapi():

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -154,7 +154,11 @@ def test_baseproperty_type_and_model():
     This checks baseproperty correctly wraps plain types in a
     `pydantic.RootModel`.
     """
-    prop = tp.BaseProperty()
+
+    class Example:
+        prop = tp.BaseProperty()
+
+    prop = Example.prop
 
     # By default, we have no type so `.type` errors.
     with pytest.raises(tp.MissingTypeError):
@@ -175,7 +179,11 @@ def test_baseproperty_type_and_model_pydantic():
     This checks baseproperty behaves correctly when its
     type is a BaseModel instance.
     """
-    prop = tp.BaseProperty()
+
+    class Example:
+        prop = tp.BaseProperty()
+
+    prop = Example.prop
 
     class MyModel(pydantic.BaseModel):
         foo: str

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -33,7 +33,7 @@ def test_thing_with_blocking_portal_error(mocker):
             self._labthings_blocking_portal = mocker.Mock()
 
     server = lt.ThingServer()
-    server.add_thing(Example(), "/example")
+    server.add_thing("example", Example)
     with pytest.RaisesGroup(pytest.RaisesExc(RuntimeError, match="blocking portal")):
         with TestClient(server.app):
             pass

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,39 +7,10 @@ be helpful to have some more bottom-up unit testing in this file.
 """
 
 import pytest
-from fastapi.testclient import TestClient
-import labthings_fastapi as lt
 from labthings_fastapi import server as ts
-
-
-def test_thing_with_blocking_portal_error(mocker):
-    """Test that a thing with a _labthings_blocking_portal causes an error.
-
-    The blocking portal is added when the server starts. If one is there already,
-    this is an error and the server should fail to start.
-
-    As this ends up in an async context manager, the exception will be wrapped
-    in an ExceptionGroup, hence the slightly complicated code to test the exception.
-
-    This is not an error condition that we expect to happen often. Handling
-    it more elegantly would result in enough additional code that the burden of
-    maintaining and testing that code outweighs the benefit of a more elegant
-    error message.
-    """
-
-    class Example(lt.Thing):
-        def __init__(self):
-            super().__init__()
-            self._labthings_blocking_portal = mocker.Mock()
-
-    server = lt.ThingServer()
-    server.add_thing("example", Example)
-    with pytest.RaisesGroup(pytest.RaisesExc(RuntimeError, match="blocking portal")):
-        with TestClient(server.app):
-            pass
 
 
 def test_server_from_config_non_thing_error():
     """Test a typeerror is raised if something that's not a Thing is added."""
     with pytest.raises(TypeError, match="not a Thing"):
-        ts.server_from_config({"things": {"/thingone": {"class": "builtins:object"}}})
+        ts.server_from_config({"things": {"thingone": {"class": "builtins:object"}}})

--- a/tests/test_server_cli.py
+++ b/tests/test_server_cli.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 
 from pytest import raises
+import pytest
 
 from labthings_fastapi import ThingServer
 from labthings_fastapi.server import server_from_config
@@ -93,12 +94,14 @@ def check_serve_from_cli(args: list[str] | None = None):
     p.run_monitored(terminate_outputs=["Application startup complete"])
 
 
+@pytest.mark.slow
 def test_serve_from_cli_with_config_json():
     """Check we can create a server from the command line, using JSON"""
     config_json = json.dumps(CONFIG)
     check_serve_from_cli(["-j", config_json])
 
 
+@pytest.mark.slow
 def test_serve_from_cli_with_config_file():
     """Check we can create a server from the command line, using a file"""
     config_json = json.dumps(CONFIG)
@@ -109,11 +112,13 @@ def test_serve_from_cli_with_config_file():
         check_serve_from_cli(["-c", temp.name])
 
 
+@pytest.mark.slow
 def test_serve_with_no_config_without_multiprocessing():
     with raises(RuntimeError):
         serve_from_cli([], dry_run=True)
 
 
+@pytest.mark.slow
 def test_serve_with_no_config():
     """Check an empty config fails, using multiprocessing.
     This is important, because if it passes it means our tests above
@@ -123,6 +128,7 @@ def test_serve_with_no_config():
         check_serve_from_cli([])
 
 
+@pytest.mark.slow
 def test_invalid_thing():
     """Check it fails for invalid things"""
     config_json = json.dumps(
@@ -136,6 +142,7 @@ def test_invalid_thing():
         check_serve_from_cli(["-j", config_json])
 
 
+@pytest.mark.slow
 def test_fallback():
     """test the fallback option
 
@@ -152,12 +159,14 @@ def test_fallback():
     check_serve_from_cli(["-j", config_json, "--fallback"])
 
 
+@pytest.mark.slow
 def test_invalid_config():
     """Check it fails for invalid config"""
     with raises(FileNotFoundError):
         check_serve_from_cli(["-c", "non_existent_file.json"])
 
 
+@pytest.mark.slow
 def test_thing_that_cannot_start():
     """Check it fails for a thing that can't start"""
     config_json = json.dumps(
@@ -169,7 +178,3 @@ def test_thing_that_cannot_start():
     )
     with raises(SystemExit):
         check_serve_from_cli(["-j", config_json])
-
-
-if __name__ == "__main__":
-    test_serve_from_cli_with_config_json()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,7 @@
 from threading import Thread
 import tempfile
 import json
+from typing import Any
 import pytest
 import os
 import logging
@@ -9,14 +10,15 @@ from fastapi.testclient import TestClient
 
 import labthings_fastapi as lt
 from labthings_fastapi.exceptions import NotConnectedToServerError
+from labthings_fastapi.thing_server_interface import create_thing_without_server
 from .temp_client import poll_task
 
 
 class ThingWithSettings(lt.Thing):
     """A test `.Thing` with some settings and actions."""
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
         # Initialize functional settings with default values
         self._floatsetting: float = 1.0
         self._localonlysetting = "Local-only default."
@@ -184,7 +186,7 @@ def server():
 
 def test_setting_available():
     """Check default settings are available before connecting to server"""
-    thing = ThingWithSettings()
+    thing = create_thing_without_server(ThingWithSettings)
     assert not thing.boolsetting
     assert thing.stringsetting == "foo"
     assert thing.floatsetting == 1.0
@@ -338,7 +340,7 @@ def test_premature_Settings_save():
     The settings path is only set when a thing is connected to a server,
     so if we use an unconnected we should see the error.
     """
-    thing = ThingWithSettings()
+    thing = create_thing_without_server(ThingWithSettings)
     with pytest.raises(NotConnectedToServerError):
         thing.save_settings()
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -9,7 +9,6 @@ import logging
 from fastapi.testclient import TestClient
 
 import labthings_fastapi as lt
-from labthings_fastapi.exceptions import NotConnectedToServerError
 from labthings_fastapi.thing_server_interface import create_thing_without_server
 from .temp_client import poll_task
 
@@ -332,17 +331,6 @@ def test_settings_dict_save(server):
         with open(setting_file, "r", encoding="utf-8") as file_obj:
             # Check settings on file match expected dictionary
             assert json.load(file_obj) == _settings_dict(dictsetting={"c": 3})
-
-
-def test_premature_Settings_save():
-    """Check a helpful error is raised if the settings path is missing.
-
-    The settings path is only set when a thing is connected to a server,
-    so if we use an unconnected we should see the error.
-    """
-    thing = create_thing_without_server(ThingWithSettings)
-    with pytest.raises(NotConnectedToServerError):
-        thing.save_settings()
 
 
 def test_settings_dict_internal_update(server):

--- a/tests/test_thing.py
+++ b/tests/test_thing.py
@@ -1,11 +1,11 @@
 from labthings_fastapi.example_things import MyThing
 from labthings_fastapi import ThingServer
+from labthings_fastapi.thing_server_interface import create_thing_without_server
 
 
 def test_td_validates():
     """This will raise an exception if it doesn't validate OK"""
-    thing = MyThing()
-    thing.path = "/mything"  # can't generate a TD without a path
+    thing = create_thing_without_server(MyThing)
     assert thing.validate_thing_description() is None
 
 

--- a/tests/test_thing.py
+++ b/tests/test_thing.py
@@ -1,4 +1,3 @@
-import pytest
 from labthings_fastapi.example_things import MyThing
 from labthings_fastapi import ThingServer
 
@@ -12,15 +11,6 @@ def test_td_validates():
 
 def test_add_thing():
     """Check that thing can be added to the server"""
-    thing = MyThing()
     server = ThingServer()
-    server.add_thing(thing, "/thing")
-
-
-def test_add_naughty_thing():
-    """Check that a thing trying to access server resources
-    using .. is not allowed"""
-    thing = MyThing()
-    server = ThingServer()
-    with pytest.raises(ValueError):
-        server.add_thing(thing, "/../../../../bin")
+    server.add_thing("thing", MyThing)
+    assert isinstance(server.things["thing"], MyThing)

--- a/tests/test_thing_connection.py
+++ b/tests/test_thing_connection.py
@@ -11,68 +11,314 @@ from labthings_fastapi.exceptions import ThingConnectionError, ThingNotConnected
 class ThingOne(lt.Thing):
     """A class that will cause chaos if it can."""
 
-    other_thing: "ThingTwo" = lt.thing_connection("thing_two")
-    multiple_things: Mapping[str, lt.Thing] = lt.thing_connection(
-        ["thing_one", "thing_two"]
-    )
-
-    @lt.thing_action
-    def say_hello(self) -> str:
-        """An example function."""
-        return "Hello from thing_one."
-
-    @lt.thing_action
-    def ask_other_thing(self) -> str:
-        """Ask ThingTwo to say hello."""
-        return self.other_thing.say_hello()
+    other_thing: "ThingTwo" = lt.thing_connection()
+    n_things: "Mapping[str, ThingThree]" = lt.thing_connection()
+    optional_thing: "ThingThree | None" = lt.thing_connection()
 
 
 class ThingTwo(lt.Thing):
     """A class that relies on ThingOne."""
 
-    other_thing: ThingOne = lt.thing_connection("thing_one")
-
-    @lt.thing_action
-    def say_hello(self) -> str:
-        """An example function."""
-        return "Hello from thing_two."
-
-    @lt.thing_action
-    def ask_other_thing(self) -> str:
-        """Ask ThingOne to say hello."""
-        return self.other_thing.say_hello()
+    other_thing: ThingOne = lt.thing_connection()
 
 
 class ThingN(lt.Thing):
     """A class that emulates ThingOne and ThingTwo more generically."""
 
-    other_thing: "ThingN" = lt.thing_connection()
-
-    @lt.thing_action
-    def say_hello(self) -> str:
-        """An example function."""
-        return f"Hello from {self.name}."
-
-    @lt.thing_action
-    def ask_other_thing(self) -> str:
-        """Ask the other thing to say hello."""
-        return self.other_thing.say_hello()
+    other_thing: "ThingN" = lt.thing_connection(None)
 
 
-class ThingOfWrongType(lt.Thing):
+class ThingThree(lt.Thing):
     """A Thing that has no other attributes."""
 
     pass
 
 
-def test_type_analysis():
+class ThingThatMustBeConfigured(lt.Thing):
+    """A Thing that has a default that won't work."""
+
+    other_thing: lt.Thing = lt.thing_connection(None)
+
+
+class Dummy:
+    """A dummy thing-like class."""
+
+    def __init__(self, name):
+        """Set the dummy Thing's name."""
+        self.name = name
+
+
+class Dummy1(Dummy):
+    """A subclass of Dummy."""
+
+
+class Dummy2(Dummy):
+    """A different subclass of Dummy."""
+
+
+class ThingWithManyConnections:
+    """A class with lots of ThingConnections.
+
+    This class is not actually meant to be used - it is a host for
+    the thing_connection attributes. It's not a Thing, to simplify
+    testing. The "thing" types it depends on are also not Things,
+    again to simplify testing.
+    """
+
+    name = "thing"
+
+    single_no_default: Dummy1 = lt.thing_connection()
+    optional_no_default: Dummy1 | None = lt.thing_connection()
+    multiple_no_default: Mapping[str, Dummy1] = lt.thing_connection()
+
+    single_default_none: Dummy1 = lt.thing_connection(None)
+    optional_default_none: Dummy1 | None = lt.thing_connection(None)
+    multiple_default_none: Mapping[str, Dummy1] = lt.thing_connection(None)
+
+    single_default_str: Dummy1 = lt.thing_connection("dummy_a")
+    optional_default_str: Dummy1 | None = lt.thing_connection("dummy_a")
+    multiple_default_str: Mapping[str, Dummy1] = lt.thing_connection("dummy_a")
+
+    single_default_seq: Dummy1 = lt.thing_connection(["dummy_a", "dummy_b"])
+    optional_default_seq: Dummy1 | None = lt.thing_connection(["dummy_a", "dummy_b"])
+    multiple_default_seq: Mapping[str, Dummy1] = lt.thing_connection(
+        ["dummy_a", "dummy_b"]
+    )
+
+
+class ThingWithFutureConnection:
+    """A class with a ThingConnection in the future."""
+
+    name = "thing"
+
+    single: "DummyFromTheFuture" = lt.thing_connection()
+    optional: "DummyFromTheFuture | None" = lt.thing_connection()
+    multiple: "Mapping[str, DummyFromTheFuture]" = lt.thing_connection()
+
+
+class DummyFromTheFuture(Dummy):
+    """A subclass of the dummy Thing defined after the dependent class."""
+
+
+def dummy_things(names, cls=Dummy1):
+    """Turn a list or set of names into a dict of Things."""
+    return {n: cls(n) for n in names}
+
+
+def names_set(thing_or_mapping):
+    """Given a mapping or a Thing, return a set of names."""
+    if thing_or_mapping is None:
+        return set()
+    if isinstance(thing_or_mapping, str):
+        return {thing_or_mapping}
+    else:
+        return {t.name for t in thing_or_mapping.values()}
+
+
+@pytest.fixture
+def mixed_things():
+    """A list of Things with two different types."""
+    return {
+        **dummy_things({"thing1_a", "thing1_b"}, Dummy1),
+        **dummy_things({"thing2_a", "thing2_b"}, Dummy2),
+    }
+
+
+CONN_TYPES = ["single", "optional", "multiple"]
+DEFAULTS = ["no_default", "default_none", "default_str", "default_seq"]
+
+
+@pytest.mark.parametrize("conn_type", CONN_TYPES)
+@pytest.mark.parametrize("default", DEFAULTS)
+def test_type_analysis(conn_type, default):
+    """Check the type of things and thing connections is correctly determined."""
+    attr = getattr(ThingWithManyConnections, f"{conn_type}_{default}")
+
+    # All the attributes use the same type of Thing, Dummy1
+    assert attr.thing_type == (Dummy1,)
+    assert attr.is_optional is (conn_type == "optional")
+    assert attr.is_mapping is (conn_type == "multiple")
+
+
+@pytest.mark.parametrize("conn_type", CONN_TYPES)
+def test_type_analysis_strings(conn_type):
+    """Check connection types still work with stringified annotations."""
+    attr = getattr(ThingWithFutureConnection, f"{conn_type}")
+
+    # All the attributes use the same type of Thing, Dummy1
+    assert attr.thing_type == (DummyFromTheFuture,)
+    assert attr.is_optional is (conn_type == "optional")
+    assert attr.is_mapping is (conn_type == "multiple")
+
+
+def test_pick_things(mixed_things):
+    r"""Test the logic that picks things from the server.
+
+    Note that ``_pick_things`` depends only on the ``thing_type`` of the connection,
+    not on whether it's optional or a mapping. Those are dealt with in ``connect``\ .
+    """
+    attr = ThingWithManyConnections.single_no_default
+
+    def picked_names(things, target):
+        return {t.name for t in attr._pick_things(things, target)}
+
+    # If the target is None, we always get an empty list.
+    for names in [[], ["thing1_a"], ["thing1_a", "thing1_b"]]:
+        assert picked_names(dummy_things(names), None) == set()
+
+    # If there are no other Things, picking by class returns nothing.
+    assert picked_names({}, ...) == set()
+
+    # If there are other Things, they should be filtered by type.
+    for names1 in [[], ["thing1_a"], ["thing1_a", "thing1_b"]]:
+        for names2 in [[], ["thing2_a"], ["thing2_a", "thing2_b"]]:
+            mixed_things = {
+                **dummy_things(names1, Dummy1),
+                **dummy_things(names2, Dummy2),
+            }
+            assert picked_names(mixed_things, ...) == set(names1)
+
+    # If a string is specified, it works when it exists and it's the right type.
+    for target in ["thing1_a", "thing1_b"]:
+        assert picked_names(mixed_things, target) == {target}
+    # If a sequence of strings is specified, it should also check existence and type.
+    # The targets below all exist and have the right type.
+    for target in [[], ["thing1_a"], ["thing1_a", "thing1_b"]]:
+        assert picked_names(mixed_things, target) == set(target)
+    # Any iterable will do - a set is not a sequence, but it is an iterable.
+    # This checks sets are OK as well.
+    for target in [set(), {"thing1_a"}, {"thing1_a", "thing1_b"}]:
+        assert picked_names(mixed_things, target) == target
+
+    # Check for the error if we specify the wrong type (for string and sequence)
+    # Note that only one thing of the wrong type will still cause the error.
+    for target in ["thing2_a", ["thing2_a"], ["thing1_a", "thing2_a"]]:
+        with pytest.raises(ThingConnectionError) as excinfo:
+            picked_names(mixed_things, target)
+        assert "wrong type" in str(excinfo.value)
+
+    # Check for a KeyError if we specify a missing Thing. This is converted to
+    # a ThingConnectionError by `connect`.
+    for target in ["something_else", {"thing1_a", "something_else"}]:
+        with pytest.raises(KeyError):
+            picked_names(mixed_things, target)
+
+    # Check for a TypeError if the target is the wrong type.
+    with pytest.raises(TypeError):
+        picked_names(mixed_things, True)
+
+
+def test_connect(mixed_things):
+    """Test connecting different attributes produces the right result"""
+    cls = ThingWithManyConnections  # This is just to save typing!
+
+    # A default of None means no things should be returned by default
+    # This is OK for optional connections and mappings, but not for
+    # connections typed as a Thing: these must always have a value.
+    for names in [set(), {"thing_a"}, {"thing_a", "thing_b"}]:
+        obj = cls()
+        cls.optional_default_none.connect(obj, dummy_things(names))
+        assert obj.optional_default_none is None
+        cls.multiple_default_none.connect(obj, dummy_things(names))
+        assert names_set(obj.multiple_default_none) == set()
+        # single should fail, as it requires a Thing
+        with pytest.raises(ThingConnectionError) as excinfo:
+            cls.single_default_none.connect(obj, dummy_things(names))
+        assert "must be set" in str(excinfo.value)
+
+    # We should be able to override this by giving names.
+    # Note that a sequence with one element and a single string are equivalent.
+    for target in ["thing1_a", ["thing1_a"]]:
+        obj = cls()
+        cls.single_default_none.connect(obj, mixed_things, target)
+        assert obj.single_default_none.name == "thing1_a"
+        cls.optional_default_none.connect(obj, mixed_things, target)
+        assert obj.optional_default_none.name == "thing1_a"
+        cls.multiple_default_none.connect(obj, mixed_things, target)
+        assert names_set(obj.multiple_default_none) == {"thing1_a"}
+
+    # A default of `...` (i.e. no default) picks by class.
+    # Different types have different constraints on how many are allowed.
+
+    # If there are no matching Things, optional and multiple are OK,
+    # but a single connection fails, as it can't be None.
+    no_matches = {n: Dummy2(n) for n in ["one", "two"]}
+    obj = cls()
+    with pytest.raises(ThingConnectionError) as excinfo:
+        cls.single_no_default.connect(obj, no_matches)
+    assert "no matching Thing" in str(excinfo.value)
+    cls.optional_no_default.connect(obj, no_matches)
+    assert obj.optional_no_default is None
+    cls.multiple_no_default.connect(obj, no_matches)
+    assert obj.multiple_no_default == {}
+
+    # If there's exactly one matching Thing, everything works.
+    match = Dummy1("three")
+    one_match = {"three": match, **no_matches}
+    obj = cls()
+    cls.single_no_default.connect(obj, one_match)
+    assert obj.single_no_default is match
+    cls.optional_no_default.connect(obj, one_match)
+    assert obj.optional_no_default is match
+    cls.multiple_no_default.connect(obj, one_match)
+    assert obj.multiple_no_default == {"three": match}
+
+    # If we have more than one match, only the multiple connection
+    # is OK.
+    match2 = Dummy1("four")
+    two_matches = {"four": match2, **one_match}
+    obj = cls()
+    with pytest.raises(ThingConnectionError) as excinfo:
+        cls.single_no_default.connect(obj, two_matches)
+    assert "multiple Things" in str(excinfo.value)
+    assert "Things by type" in str(excinfo.value)
+    with pytest.raises(ThingConnectionError) as excinfo:
+        cls.optional_no_default.connect(obj, two_matches)
+    assert "multiple Things" in str(excinfo.value)
+    assert "Things by type" in str(excinfo.value)
+    cls.multiple_no_default.connect(obj, two_matches)
+    assert obj.multiple_no_default == {"three": match, "four": match2}
+
+    # _pick_things raises KeyErrors for invalid names.
+    # Check KeyErrors are turned back into ThingConnectionErrors
+    obj = cls()
+    with pytest.raises(ThingConnectionError) as excinfo:
+        cls.single_default_str.connect(obj, mixed_things)
+    assert "not the name of a Thing" in str(excinfo.value)
+    assert f"{obj.name}.single_default_str" in str(excinfo.value)
+    assert "not configured, and used the default" in str(excinfo.value)
+    # The error message changes if a target is specified.
+    obj = cls()
+    with pytest.raises(ThingConnectionError) as excinfo:
+        cls.single_default_str.connect(obj, mixed_things, "missing")
+    assert "not the name of a Thing" in str(excinfo.value)
+    assert f"{obj.name}.single_default_str" in str(excinfo.value)
+    assert "configured to connect to 'missing'" in str(excinfo.value)
+
+
+def test_readonly():
+    """Test that thing connections are read-only."""
+    obj = ThingWithManyConnections()
+    with pytest.raises(AttributeError, match="read-only"):
+        obj.single_default_none = Dummy("name")
+
+
+# The tests below use real Things and a real ThingServer to do more
+# realistic tests. These are not as exhaustive as the tests above,
+# but I think there's no harm in taking both approaches.
+def test_type_analysis_thingone():
     """Check the correct properties are inferred from the type hints."""
     assert ThingOne.other_thing.is_optional is False
     assert ThingOne.other_thing.is_mapping is False
-    assert ThingOne.other_thing.thing_type is ThingTwo
-    assert ThingOne.multiple_things.is_optional is False
-    assert ThingOne.multiple_things.is_mapping is True
-    assert ThingOne.multiple_things.thing_type is lt.Thing
+    assert ThingOne.other_thing.thing_type == (ThingTwo,)
+
+    assert ThingOne.n_things.is_optional is False
+    assert ThingOne.n_things.is_mapping is True
+    assert ThingOne.n_things.thing_type == (ThingThree,)
+
+    assert ThingOne.optional_thing.is_optional is True
+    assert ThingOne.optional_thing.is_mapping is False
+    assert ThingOne.optional_thing.thing_type == (ThingThree,)
 
 
 CONNECTIONS = {
@@ -89,7 +335,7 @@ CONNECTIONS = {
         (ThingN, ThingN, CONNECTIONS),
     ],
 )
-def test_thing_connection(cls_1, cls_2, connections) -> None:
+def test_circular_connection(cls_1, cls_2, connections) -> None:
     """Check that two things can connect to each other.
 
     Note that this test includes a circular dependency, which is fine.
@@ -101,48 +347,58 @@ def test_thing_connection(cls_1, cls_2, connections) -> None:
     thing_one = server.add_thing("thing_one", cls_1)
     thing_two = server.add_thing("thing_two", cls_2)
     things = [thing_one, thing_two]
-    numbers = ["one", "two"]
     if connections is not None:
         server.thing_connections = connections
-
-    # Check the things say hello correctly
-    for thing, num in zip(things, numbers, strict=True):
-        assert thing.say_hello() == f"Hello from thing_{num}."
 
     # Check the connections don't work initially, because they aren't connected
     for thing in things:
         with pytest.raises(ThingNotConnectedError):
-            thing.ask_other_thing()
+            _ = thing.other_thing
 
-    with TestClient(server.app) as client:
+    with TestClient(server.app) as _:
         # The things should be connected as the server is now running
+        for thing, other in zip(things, reversed(things), strict=True):
+            assert thing.other_thing is other
 
-        # Check the things are connected, calling actions directly
-        for thing, num in zip(things, reversed(numbers), strict=True):
-            assert thing.ask_other_thing() == f"Hello from thing_{num}."
 
-        # Check the same happens over "HTTP" (i.e. the TestClient)
-        for num, othernum in zip(numbers, reversed(numbers), strict=True):
-            thing = lt.ThingClient.from_url(f"/thing_{num}/", client=client)
-            assert thing.ask_other_thing() == f"Hello from thing_{othernum}."
-            assert thing.say_hello() == f"Hello from thing_{num}."
+def connectionerror_starting_server(server):
+    """Attempt to start a server, and return the error as a string."""
+    with pytest.RaisesGroup(ThingConnectionError) as excinfo:
+        # Creating a TestClient starts the server
+        with TestClient(server.app):
+            pass
+    # excinfo contains an ExceptionGroup because TestClient runs in a
+    # task group, hence the use of RaisesGroup and the `.exceptions[0]`
+    # below.
+    return str(excinfo.value.exceptions[0])
 
 
 @pytest.mark.parametrize(
     ("connections", "error"),
     [
-        ({}, "no default"),
-        ({"thing_one": {"other_thing": "non_existent_thing"}}, "does not exist"),
-        ({"thing_one": {"other_thing": ("thing_one", "thing_one")}}, "single Thing"),
-        ({"thing_one": {"other_thing": "wrong_type_thing"}}, "not of type"),
-        ({"thing_one": {"other_thing": "thing_one"}}, None),
+        ({}, "must be set"),
+        ({"thing_one": {"other_thing": "non_thing"}}, "not the name of a Thing"),
+        ({"thing_one": {"other_thing": "thing_three"}}, "wrong type"),
+        (
+            {
+                "thing_one": {"other_thing": "thing_one"},
+                "thing_two": {"other_thing": "thing_one"},
+            },
+            None,
+        ),
     ],
 )
-def test_connections_no_default(connections, error):
-    """Check a connection with no default and no config errors out."""
+def test_connections_none_default(connections, error):
+    """Check error conditions for a connection with a default of None.
+
+    Note that we only catch the first error - that's why we only need
+    to specify connections for 'thing_two' in the last case - because
+    that's the only one where 'thing_one' connects successfully.
+    """
     server = lt.ThingServer()
     thing_one = server.add_thing("thing_one", ThingN)
-    server.add_thing("wrong_type_thing", ThingOfWrongType)
+    server.add_thing("thing_two", ThingN)
+    server.add_thing("thing_three", ThingThree)
 
     server.thing_connections = connections
 
@@ -151,11 +407,39 @@ def test_connections_no_default(connections, error):
             assert thing_one.other_thing is thing_one
         return
 
-    with pytest.RaisesGroup(ThingConnectionError) as excinfo:
-        # Creating a TestClient should activate the connections
-        with TestClient(server.app):
-            pass
-    # excinfo contains an ExceptionGroup because TestClient runs in a
-    # task group, hence the use of RaisesGroup and the `.exceptions[0]`
-    # below.
-    assert error in str(excinfo.value.exceptions[0])
+    assert error in connectionerror_starting_server(server)
+
+
+def test_optional_and_empty():
+    """Check that an optional or mapping connection can be None/empty."""
+    server = lt.ThingServer()
+    thing_one = server.add_thing("thing_one", ThingOne)
+    _thing_two = server.add_thing("thing_two", ThingTwo)
+
+    with TestClient(server.app):
+        assert thing_one.optional_thing is None
+        assert len(thing_one.n_things) == 0
+
+
+def test_mapping_and_multiple():
+    """Check that a mapping connection can pick up several Things.
+
+    This also tests the expected error if multiple things match a
+    single connection.
+    """
+    server = lt.ThingServer()
+    thing_one = server.add_thing("thing_one", ThingOne)
+    _thing_two = server.add_thing("thing_two", ThingTwo)
+    for i in range(3):
+        server.add_thing(f"thing_{i + 3}", ThingThree)
+
+    # Attempting to start the server should fail, because
+    # thing_one.optional_thing will match multiple ThingThree instances.
+    assert "multiple Things" in connectionerror_starting_server(server)
+
+    # Set optional thing to one specific name and it will start OK.
+    server.thing_connections = {"thing_one": {"optional_thing": "thing_3"}}
+
+    with TestClient(server.app):
+        assert thing_one.optional_thing.name == "thing_3"
+        assert names_set(thing_one.n_things) == {f"thing_{i + 3}" for i in range(3)}

--- a/tests/test_thing_connection.py
+++ b/tests/test_thing_connection.py
@@ -1,6 +1,7 @@
 """Test the thing_connection module."""
 
 from collections.abc import Mapping
+import gc
 import pytest
 import labthings_fastapi as lt
 from fastapi.testclient import TestClient
@@ -301,6 +302,17 @@ def test_readonly():
     obj = ThingWithManyConnections()
     with pytest.raises(AttributeError, match="read-only"):
         obj.single_default_none = Dummy("name")
+
+
+def test_referenceerror():
+    """Check an error is raised by premature deletion."""
+    obj = ThingWithManyConnections()
+    things = {"name": Dummy1("name")}
+    ThingWithManyConnections.single_no_default.connect(obj, things)
+    del things
+    gc.collect()
+    with pytest.raises(ReferenceError):
+        _ = obj.single_no_default
 
 
 # The tests below use real Things and a real ThingServer to do more

--- a/tests/test_thing_connection.py
+++ b/tests/test_thing_connection.py
@@ -1,0 +1,138 @@
+"""Test the thing_connection module."""
+
+import pytest
+import labthings_fastapi as lt
+from fastapi.testclient import TestClient
+
+from labthings_fastapi.exceptions import ThingConnectionError, ThingNotConnectedError
+
+
+class ThingOne(lt.Thing):
+    """A class that will cause chaos if it can."""
+
+    thing_two: "ThingTwo" = lt.thing_connection("thing_two")
+
+    @lt.thing_action
+    def say_hello(self) -> str:
+        """An example function."""
+        return "Hello from thing_one."
+
+    @lt.thing_action
+    def ask_other_thing(self) -> str:
+        """Ask ThingTwo to say hello."""
+        return self.thing_two.say_hello()
+
+
+class ThingTwo(lt.Thing):
+    """A class that relies on ThingOne."""
+
+    thing_one: ThingOne = lt.thing_connection("thing_one")
+
+    @lt.thing_action
+    def say_hello(self) -> str:
+        """An example function."""
+        return "Hello from thing_two."
+
+    @lt.thing_action
+    def ask_other_thing(self) -> str:
+        """Ask ThingOne to say hello."""
+        return self.thing_one.say_hello()
+
+
+class ThingN(lt.Thing):
+    """A class that emulates ThingOne and ThingTwo more generically."""
+
+    other_thing: "ThingN" = lt.thing_connection()
+
+    @lt.thing_action
+    def say_hello(self) -> str:
+        """An example function."""
+        return f"Hello from {self.name}."
+
+    @lt.thing_action
+    def ask_other_thing(self) -> str:
+        """Ask the other thing to say hello."""
+        return self.other_thing.say_hello()
+
+
+CONNECTIONS = {
+    "thing_one": {"other_thing": "thing_two"},
+    "thing_two": {"other_thing": "thing_one"},
+}
+
+
+@pytest.mark.parametrize(
+    ("cls_1", "cls_2", "connections"),
+    [
+        (ThingOne, ThingTwo, None),
+        (ThingOne, ThingTwo, CONNECTIONS),
+        (ThingN, ThingN, CONNECTIONS),
+    ],
+)
+def test_thing_connection(cls_1, cls_2, connections) -> None:
+    """Check that two things can connect to each other.
+
+    Note that this test includes a circular dependency, which is fine.
+    No checks are made for infinite loops: that's up to the author of the
+    Thing classes. Circular dependencies should not cause any problems for
+    the LabThings server.
+    """
+    server = lt.ThingServer()
+    thing_one = server.add_thing("thing_one", cls_1)
+    thing_two = server.add_thing("thing_two", cls_2)
+    things = [thing_one, thing_two]
+    numbers = ["one", "two"]
+    if connections is not None:
+        server.thing_connections = connections
+
+    # Check the things say hello correctly
+    for thing, num in zip(things, numbers, strict=True):
+        assert thing.say_hello() == f"Hello from thing_{num}."
+
+    # Check the connections don't work initially, because they aren't connected
+    for thing in things:
+        with pytest.raises(ThingNotConnectedError):
+            thing.ask_other_thing()
+
+    with TestClient(server.app) as client:
+        # The things should be connected as the server is now running
+
+        # Check the things are connected, calling actions directly
+        for thing, num in zip(things, reversed(numbers), strict=True):
+            assert thing.ask_other_thing() == f"Hello from thing_{num}."
+
+        # Check the same happens over "HTTP" (i.e. the TestClient)
+        for num, othernum in zip(numbers, reversed(numbers), strict=True):
+            thing = lt.ThingClient.from_url(f"/thing_{num}/", client=client)
+            assert thing.ask_other_thing() == f"Hello from thing_{othernum}."
+            assert thing.say_hello() == f"Hello from thing_{num}."
+
+
+@pytest.mark.parametrize(
+    ("connections", "error"),
+    [
+        # No default, no configuration - error should say so.
+        (None, "no default"),
+        # Configured to connect to a missing thing
+        ({"thing_one": {"other_thing": "non_existent_thing"}}, "does not exist"),
+        # Configured to connect to a thing that exists, but is the wrong type
+        ({"thing_one": {"other_thing": "thing_two"}}, "must be of type"),
+    ],
+)
+def test_thing_connection_errors(connections, error) -> None:
+    """Check that a ThingConnection without a default raises an error."""
+    server = lt.ThingServer()
+    server.add_thing("thing_one", ThingN)
+    server.add_thing("thing_two", ThingTwo)
+
+    if connections is not None:
+        server.thing_connections = connections
+
+    with pytest.RaisesGroup(ThingConnectionError) as excinfo:
+        # Creating a TestClient should activate the connections
+        with TestClient(server.app):
+            pass
+    # excinfo contains an ExceptionGroup because TestClient runs in a
+    # task group, hence the use of RaisesGroup and the `.exceptions[0]`
+    # below.
+    assert error in str(excinfo.value.exceptions[0])

--- a/tests/test_thing_dependencies.py
+++ b/tests/test_thing_dependencies.py
@@ -24,7 +24,7 @@ class ThingOne(lt.Thing):
         return self.ACTION_ONE_RESULT
 
 
-ThingOneDep = lt.deps.direct_thing_client_dependency(ThingOne, "/thing_one/")
+ThingOneDep = lt.deps.direct_thing_client_dependency(ThingOne, "thing_one")
 
 
 class ThingTwo(lt.Thing):
@@ -39,7 +39,7 @@ class ThingTwo(lt.Thing):
         return thing_one.action_one()
 
 
-ThingTwoDep = lt.deps.direct_thing_client_dependency(ThingTwo, "/thing_two/")
+ThingTwoDep = lt.deps.direct_thing_client_dependency(ThingTwo, "thing_two")
 
 
 class ThingThree(lt.Thing):
@@ -57,8 +57,8 @@ def dependency_names(func: callable) -> list[str]:
 
 def test_direct_thing_dependency():
     """Check that direct thing clients are distinct classes"""
-    ThingOneClient = direct_thing_client_class(ThingOne, "/thing_one/")
-    ThingTwoClient = direct_thing_client_class(ThingTwo, "/thing_two/")
+    ThingOneClient = direct_thing_client_class(ThingOne, "thing_one")
+    ThingTwoClient = direct_thing_client_class(ThingTwo, "thing_two")
     print(f"{ThingOneClient}: ThingOneClient{inspect.signature(ThingOneClient)}")
     for k in dir(ThingOneClient):
         if k.startswith("__"):
@@ -81,8 +81,8 @@ def test_interthing_dependency():
     This uses the internal thing client mechanism.
     """
     server = lt.ThingServer()
-    server.add_thing(ThingOne(), "/thing_one")
-    server.add_thing(ThingTwo(), "/thing_two")
+    server.add_thing("thing_one", ThingOne)
+    server.add_thing("thing_two", ThingTwo)
     with TestClient(server.app) as client:
         r = client.post("/thing_two/action_two")
         invocation = poll_task(client, r.json())
@@ -97,9 +97,9 @@ def test_interthing_dependency_with_dependencies():
     dependency injection for the called action
     """
     server = lt.ThingServer()
-    server.add_thing(ThingOne(), "/thing_one")
-    server.add_thing(ThingTwo(), "/thing_two")
-    server.add_thing(ThingThree(), "/thing_three")
+    server.add_thing("thing_one", ThingOne)
+    server.add_thing("thing_two", ThingTwo)
+    server.add_thing("thing_three", ThingThree)
     with TestClient(server.app) as client:
         r = client.post("/thing_three/action_three")
         r.raise_for_status()
@@ -122,8 +122,8 @@ def test_raw_interthing_dependency():
             return thing_one.action_one()
 
     server = lt.ThingServer()
-    server.add_thing(ThingOne(), "/thing_one")
-    server.add_thing(ThingTwo(), "/thing_two")
+    server.add_thing("thing_one", ThingOne)
+    server.add_thing("thing_two", ThingTwo)
     with TestClient(server.app) as client:
         r = client.post("/thing_two/action_two")
         invocation = poll_task(client, r.json())
@@ -153,7 +153,7 @@ def test_conflicting_dependencies():
             return thing_two.action_two()
 
     with pytest.raises(lt.client.in_server.DependencyNameClashError):
-        lt.deps.direct_thing_client_dependency(ThingFour, "/thing_four/")
+        lt.deps.direct_thing_client_dependency(ThingFour, "thing_four")
 
 
 def check_request():

--- a/tests/test_thing_lifecycle.py
+++ b/tests/test_thing_lifecycle.py
@@ -16,14 +16,14 @@ class TestThing(lt.Thing):
         self.alive = False
 
 
-thing = TestThing()
 server = lt.ThingServer()
-server.add_thing(thing, "/thing")
+thing = server.add_thing("thing", TestThing)
 
 
 def test_thing_alive():
     assert thing.alive is False
     with TestClient(server.app) as client:
+        assert thing.alive is True
         r = client.get("/thing/alive")
         assert r.json() is True
     assert thing.alive is False

--- a/tests/test_thing_server_interface.py
+++ b/tests/test_thing_server_interface.py
@@ -1,0 +1,154 @@
+"""Test the ThingServerInterface class and associated features."""
+
+import gc
+import os
+import tempfile
+
+from fastapi.testclient import TestClient
+import pytest
+
+import labthings_fastapi as lt
+from labthings_fastapi.exceptions import ServerNotRunningError
+from labthings_fastapi import thing_server_interface as tsi
+
+
+NAME = "testname"
+EXAMPLE_THING_STATE = {"foo": "bar"}
+
+
+class ExampleThing(lt.Thing):
+    @lt.property
+    def thing_state(self):
+        return EXAMPLE_THING_STATE
+
+
+@pytest.fixture
+def server():
+    """Return a LabThings server"""
+    with tempfile.TemporaryDirectory() as dir:
+        server = lt.ThingServer(settings_folder=dir)
+        server.add_thing("example", ExampleThing)
+        yield server
+
+
+@pytest.fixture
+def interface(server):
+    """Return a ThingServerInterface, connected to a server."""
+    return tsi.ThingServerInterface(server, NAME)
+
+
+@pytest.fixture
+def mockinterface():
+    """Return a MockThingServerInterface."""
+    return tsi.MockThingServerInterface(NAME)
+
+
+def test_get_server(server, interface):
+    """Check the server is retrieved correctly.
+
+    This also tests for the right error if it's missing.
+    """
+    assert interface._get_server() is server
+
+
+def test_get_server_error():
+    """Ensure a helpful error is raised if the server is deleted.
+
+    This is an error condition that I would find surprising if it
+    ever occurred, but it's worth checking.
+    """
+    server = lt.ThingServer()
+    interface = tsi.ThingServerInterface(server, NAME)
+    assert interface._get_server() is server
+    del server
+    gc.collect()
+    with pytest.raises(tsi.ThingServerMissingError):
+        interface._get_server()
+
+
+def test_start_async_task_soon(server, interface):
+    """Check async tasks may be run in the event loop."""
+    mutable = [False]
+
+    async def set_mutable(val):
+        mutable[0] = val
+
+    with pytest.raises(ServerNotRunningError):
+        # You can't run async code unless the server
+        # is running: this should raise a helpful
+        # error.
+        interface.start_async_task_soon(set_mutable, True)
+
+    with TestClient(server.app) as _:
+        # TestClient starts an event loop in the background
+        # so this should work
+        interface.start_async_task_soon(set_mutable, True)
+
+    # Check the async code really did run.
+    assert mutable[0] is True
+
+
+def test_settings_folder(server, interface):
+    """Check the interface returns the right settings folder."""
+    assert interface.settings_folder == os.path.join(server.settings_folder, NAME)
+
+
+def test_settings_file_path(server, interface):
+    """Check the settings file path is as expected."""
+    assert interface.settings_file_path == os.path.join(
+        server.settings_folder, NAME, "settings.json"
+    )
+
+
+def test_name(server, interface):
+    """Check the thing's name is passed on correctly."""
+    assert interface.name is NAME
+    assert server.things["example"]._thing_server_interface.name == "example"
+
+
+def test_path(interface, server):
+    """Check the thing's path is generated predictably."""
+    assert interface.path == f"/{NAME}/"
+    assert server.things["example"].path == "/example/"
+
+
+def test_get_thing_states(interface):
+    """Check thing metadata is retrieved properly."""
+    states = interface.get_thing_states()
+    assert states == {"example": EXAMPLE_THING_STATE}
+
+
+def test_mock_start_async_task_soon(mockinterface):
+    """Check nothing happens when we run an async task."""
+    mutable = [False]
+
+    async def set_mutable(val):
+        mutable[0] = val
+
+    mockinterface.start_async_task_soon(set_mutable, True)
+
+    # Check the async code didn't run
+    assert mutable[0] is False
+
+
+def test_mock_settings_folder(mockinterface):
+    """Check a temporary settings folder is provided."""
+    # The temp folder should be created when accessed,
+    # so is None initially.
+    assert mockinterface._settings_tempdir is None
+    f = mockinterface.settings_folder
+    assert f == mockinterface._settings_tempdir.name
+    assert mockinterface.settings_file_path == os.path.join(f, "settings.json")
+
+
+def test_mock_get_thing_states(mockinterface):
+    """Check an empty dictionary is returned."""
+    assert mockinterface.get_thing_states() == {}
+
+
+def test_create_thing_without_server():
+    """Check the test harness for creating things without a server."""
+    example = tsi.create_thing_without_server(ExampleThing)
+    assert isinstance(example, ExampleThing)
+    assert example.path == "/examplething/"
+    assert isinstance(example._thing_server_interface, tsi.MockThingServerInterface)

--- a/tests/test_thing_server_interface.py
+++ b/tests/test_thing_server_interface.py
@@ -108,7 +108,16 @@ def test_name(server, interface):
 
 def test_path(interface, server):
     """Check the thing's path is generated predictably."""
+    with pytest.raises(KeyError):
+        # `interface` is for a thing called NAME, which isn't
+        # added to the server, so when we try to get its path
+        # it should raise an error.
+        _ = interface.path
+    # If we put something in the dictionary of things, it should work.
+    server._things[NAME] = None
     assert interface.path == f"/{NAME}/"
+    # We can also check the example thing, which is actually added to the server.
+    # This doesn't need any mocking.
     assert server.things["example"].path == "/example/"
 
 
@@ -139,6 +148,11 @@ def test_mock_settings_folder(mockinterface):
     f = mockinterface.settings_folder
     assert f == mockinterface._settings_tempdir.name
     assert mockinterface.settings_file_path == os.path.join(f, "settings.json")
+
+
+def test_mock_path(mockinterface):
+    """Check the path is generated predictably."""
+    assert mockinterface.path == f"/{NAME}/"
 
 
 def test_mock_get_thing_states(mockinterface):

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -52,16 +52,10 @@ class ThingWithProperties(lt.Thing):
 
 
 @pytest.fixture
-def thing():
-    """Instantiate and return a test Thing."""
-    return ThingWithProperties()
-
-
-@pytest.fixture
-def server(thing):
+def server():
     """Create a server, and add a MyThing test Thing to it."""
     server = lt.ThingServer()
-    server.add_thing(thing, "/thing")
+    server.add_thing("thing", ThingWithProperties)
     return server
 
 
@@ -84,6 +78,12 @@ def ws(client):
             yield ws
         finally:
             ws.close(1000)
+
+
+@pytest.fixture
+def thing():
+    """Create a ThingWithProperties, not connected to a server."""
+    return ThingWithProperties()
 
 
 def test_observing_dataprop(thing, mocker):

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -5,6 +5,7 @@ from labthings_fastapi.exceptions import (
     PropertyNotObservableError,
     InvocationCancelledError,
 )
+from labthings_fastapi.thing_server_interface import create_thing_without_server
 
 
 class ThingWithProperties(lt.Thing):
@@ -68,7 +69,7 @@ def client(server):
 
 @pytest.fixture
 def ws(client):
-    """Yield a websocket connection to a server hosting a MyThing().
+    """Yield a websocket connection to a server hosting a MyThing.
 
     This ensures the websocket is properly closed after the test, and
     avoids lots of indent levels.
@@ -83,7 +84,7 @@ def ws(client):
 @pytest.fixture
 def thing():
     """Create a ThingWithProperties, not connected to a server."""
-    return ThingWithProperties()
+    return create_thing_without_server(ThingWithProperties)
 
 
 def test_observing_dataprop(thing, mocker):

--- a/typing_tests/thing_definitions.py
+++ b/typing_tests/thing_definitions.py
@@ -26,6 +26,8 @@ from labthings_fastapi.properties import FunctionalProperty
 from typing_extensions import assert_type
 import typing
 
+from labthings_fastapi.thing_server_interface import create_thing_without_server
+
 
 def optional_int_factory() -> int | None:
     """Return an optional int."""
@@ -107,7 +109,8 @@ class TestPropertyDefaultsMatch(lt.Thing):
 
 
 # Check that the type hints on an instance of the class are correct.
-test_defaults_match = TestPropertyDefaultsMatch()
+test_defaults_match = create_thing_without_server(TestPropertyDefaultsMatch)
+assert_type(test_defaults_match, TestPropertyDefaultsMatch)
 assert_type(test_defaults_match.intprop, int)
 assert_type(test_defaults_match.intprop2, int)
 assert_type(test_defaults_match.intprop3, int)
@@ -167,7 +170,8 @@ class TestExplicitDescriptor(lt.Thing):
 
 
 # Check instance attributes are typed correctly.
-test_explicit_descriptor = TestExplicitDescriptor()
+test_explicit_descriptor = create_thing_without_server(TestExplicitDescriptor)
+assert_type(test_explicit_descriptor, TestExplicitDescriptor)
 assert_type(test_explicit_descriptor.intprop1, int)
 assert_type(test_explicit_descriptor.intprop2, int)
 assert_type(test_explicit_descriptor.intprop3, int)
@@ -270,7 +274,8 @@ assert_type(TestFunctionalProperty.fprop, FunctionalProperty[int])
 # Don't check ``strprop`` because it caused an error and thus will
 # not have the right type, even though the error is ignored.
 
-test_functional_property = TestFunctionalProperty()
+test_functional_property = create_thing_without_server(TestFunctionalProperty)
+assert_type(test_functional_property, TestFunctionalProperty)
 assert_type(test_functional_property.intprop1, int)
 assert_type(test_functional_property.intprop2, int)
 assert_type(test_functional_property.intprop3, int)


### PR DESCRIPTION
This MR introduces a new descriptor, `lt.thing_connection`. This provides a way to connect Things together, without using dependencies. As with `lt.property`, it uses the type hint to determine the type of the Thing it should supply. Most of the time, this is all that's needed:

```python

import labthings_fastapi as lt

class ThingA(lt.Thing):
    "A Thing to use as an example"

class ThingB(lt.Thing):
    "A class that relies on ThingA."

    thing_a: ThingA = lt.thing_connection()

    @lt.thing_action
    def test_thing_a(self):
        assert isinstance(self.thing_a, ThingA)
```

When one Thing of each type is added to a server, the descriptor will automatically be connected to the Thing of the specified type. It's also possible to specify connections, for example if there's more than one Thing of a given type.

There is support for optional connections, which don't cause an error if no Thing is available, and for connections to multiple Things. At the moment, this is only documented in docstrings in the `thing_connections` module, it should probably be a conceptual page.

Things to do before it's finished:
* [ ] Check documentation builds nicely
* [ ] Add a way to configure connections from a config file, or as an argument to `lt.ThingServer.add_thing`